### PR TITLE
feat: add private table for performant author lookup + notification creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ firebase-debug.log
 database-debug.log
 firebase-data/
 firebase-export-*/
+/scripts/service-account.json

--- a/database.rules.json
+++ b/database.rules.json
@@ -31,14 +31,14 @@
         "posts": {
           "$post_id": {
             ".validate": "newData.val() === true",
-            ".write": "auth != null && auth.uid === $uid && ( (!data.exists() ? newData.parent().parent().parent().parent().child('posts/' + $post_id).exists() : true) && (!newData.exists() ? !newData.parent().parent().parent().parent().child('posts/' + $post_id).exists() : true) )"
+            ".write": "auth != null && auth.uid === $uid && ( (!data.exists() ? (newData.parent().parent().parent().parent().child('posts').child($post_id).exists() && newData.parent().parent().parent().parent().child('authorLookup').child($post_id).child('uid').val() === $uid) : true) && (!newData.exists() ? !newData.parent().parent().parent().parent().child('posts').child($post_id).exists() : true) )"
           }
         },
         "replies": {
           "$post_id": {
             "$reply_id": {
               ".validate": "newData.val() === true",
-              ".write": "auth != null && auth.uid === $uid && ( (!data.exists() ? newData.parent().parent().parent().parent().parent().child('replies/' + $post_id + '/' + $reply_id).exists() : true) && (!newData.exists() ? !newData.parent().parent().parent().parent().parent().child('replies/' + $post_id + '/' + $reply_id).exists() : true) )"
+              ".write": "auth != null && auth.uid === $uid && ( (!data.exists() ? (newData.parent().parent().parent().parent().parent().child('replies').child($post_id).child($reply_id).exists() && newData.parent().parent().parent().parent().parent().child('authorLookup').child($reply_id).child('uid').val() === $uid) : true) && (!newData.exists() ? !newData.parent().parent().parent().parent().parent().child('replies').child($post_id).child($reply_id).exists() : true) )"
             }
           }
         },
@@ -47,13 +47,28 @@
             "$reply_id": {
               "$subreply_id": {
                 ".validate": "newData.val() === true",
-                ".write": "auth != null && auth.uid === $uid && ( (!data.exists() ? newData.parent().parent().parent().parent().parent().parent().child('subreplies/' + $post_id + '/' + $reply_id + '/' + $subreply_id).exists() : true) && (!newData.exists() ? !newData.parent().parent().parent().parent().parent().parent().child('subreplies/' + $post_id + '/' + $reply_id + '/' + $subreply_id).exists() : true) )"
+                ".write": "auth != null && auth.uid === $uid && ( (!data.exists() ? (newData.parent().parent().parent().parent().parent().parent().child('subreplies').child($post_id).child($reply_id).child($subreply_id).exists() && newData.parent().parent().parent().parent().parent().parent().child('authorLookup').child($subreply_id).child('uid').val() === $uid) : true) && (!newData.exists() ? !newData.parent().parent().parent().parent().parent().parent().child('subreplies').child($post_id).child($reply_id).child($subreply_id).exists() : true) )"
               }
             }
           }
+        }
+      }
+    },
+    "authorLookup": {
+      "$id": {
+        ".read": false,
+        ".write": "auth != null && ( ( !data.exists() && newData.child('uid').val() === auth.uid && ( (newData.child('type').val() === 'post' && newData.parent().parent().child('posts').child($id).exists() && newData.parent().parent().child('users').child(auth.uid).child('posts').child($id).exists()) || (newData.child('type').val() === 'reply' && newData.hasChild('postId') && newData.parent().parent().child('replies').child(newData.child('postId').val() + '').child($id).exists() && newData.parent().parent().child('users').child(auth.uid).child('replies').child(newData.child('postId').val() + '').child($id).exists()) || (newData.child('type').val() === 'subreply' && newData.hasChild('postId') && newData.hasChild('replyId') && newData.parent().parent().child('subreplies').child(newData.child('postId').val() + '').child(newData.child('replyId').val() + '').child($id).exists() && newData.parent().parent().child('users').child(auth.uid).child('subreplies').child(newData.child('postId').val() + '').child(newData.child('replyId').val() + '').child($id).exists()) ) ) || ( data.exists() && data.child('uid').val() === auth.uid && !newData.exists() ) )",
+        "uid": {
+          ".validate": "newData.isString()"
         },
-        "postInteractions": {
-          ".write": "false"
+        "type": {
+          ".validate": "newData.isString() && (newData.val() === 'post' || newData.val() === 'reply' || newData.val() === 'subreply')"
+        },
+        "postId": {
+          ".validate": "!newData.exists() || newData.isString()"
+        },
+        "replyId": {
+          ".validate": "!newData.exists() || newData.isString()"
         }
       }
     },
@@ -63,17 +78,16 @@
       ],
       ".read": true,
       "$post_id": {
-        ".write": "auth != null && ( (data.exists() && (data.child('userId').val() === auth.uid || root.child('users/' + auth.uid + '/posts/' + $post_id).exists()) && (!newData.exists() ? !newData.parent().parent().child('users/' + auth.uid + '/posts/' + $post_id).exists() : true)) || (!data.exists() && newData.parent().parent().child('users/' + auth.uid + '/posts/' + $post_id).exists()) )",
+        ".write": "auth != null && ( (!data.exists() && newData.parent().parent().child('authorLookup').child($post_id).child('uid').val() === auth.uid && newData.parent().parent().child('users').child(auth.uid).child('posts').child($post_id).exists()) || (data.exists() && root.child('authorLookup').child($post_id).child('uid').val() === auth.uid && (!newData.exists() ? !newData.parent().parent().child('authorLookup').child($post_id).exists() && !newData.parent().parent().child('users').child(auth.uid).child('posts').child($post_id).exists() : true)) )",
         ".validate": "!newData.exists() || (data.exists() || newData.hasChildren(['postContent', 'timestamp', 'replyCount']))",
-        "replyCount": {
-          ".write": false,
-          ".validate": "newData.isNumber() && newData.val() == 0"
-        },
-        "userInteractions": {
-          ".write": false
+        "id": {
+          ".validate": "!newData.exists() || (newData.val() === $post_id && (!data.exists() || data.val() === newData.val()))"
         },
         "userId": {
-          ".validate": "!newData.exists() || (newData.val() === auth.uid && (!data.exists() || data.val() === newData.val()))"
+          ".validate": "!newData.exists()"
+        },
+        "replyCount": {
+          ".validate": "!data.exists() ? newData.val() == 0 : newData.val() == data.val()"
         },
         "postContent": {
           ".validate": "!newData.exists() || (newData.isString() && newData.val().length <= 600)"
@@ -92,28 +106,26 @@
           "timestamp"
         ],
         ".read": true,
-        ".write": false,
         "$reply_id": {
-          ".write": "auth != null && ( (data.exists() && (data.child('userId').val() === auth.uid || root.child('users/' + auth.uid + '/replies/' + $post_id + '/' + $reply_id).exists()) && (!newData.exists() ? !newData.parent().parent().parent().child('users/' + auth.uid + '/replies/' + $post_id + '/' + $reply_id).exists() : true)) || (!data.exists() && newData.parent().parent().parent().child('users/' + auth.uid + '/replies/' + $post_id + '/' + $reply_id).exists()) )",
+          ".write": "auth != null && ( (!data.exists() && newData.parent().parent().parent().child('authorLookup').child($reply_id).child('uid').val() === auth.uid && newData.parent().parent().parent().child('users').child(auth.uid).child('replies').child($post_id).child($reply_id).exists()) || (data.exists() && root.child('authorLookup').child($reply_id).child('uid').val() === auth.uid && (!newData.exists() ? !newData.parent().parent().parent().child('authorLookup').child($reply_id).exists() && !newData.parent().parent().parent().child('users').child(auth.uid).child('replies').child($post_id).child($reply_id).exists() : true)) )",
           ".validate": "!newData.exists() || (data.exists() || newData.hasChildren(['postContent', 'timestamp', 'parentPostId', 'interactionScore', 'replyCount']))",
-          "userInteractions": {
-            ".write": false
-          },
-          "replyCount": {
-            ".write": false,
-            ".validate": "newData.isNumber() && newData.val() == 0"
+          "id": {
+            ".validate": "!newData.exists() || (newData.val() === $reply_id && (!data.exists() || data.val() === newData.val()))"
           },
           "userId": {
-            ".validate": "!newData.exists() || newData.val() === auth.uid"
+            ".validate": "!newData.exists()"
           },
           "parentPostId": {
             ".validate": "!newData.exists() || newData.val() === $post_id"
           },
-          "postContent": {
-            ".validate": "!newData.exists() || (newData.isString() && newData.val().length <= 600)"
+          "replyCount": {
+            ".validate": "!data.exists() ? newData.val() == 0 : newData.val() == data.val()"
           },
           "interactionScore": {
             ".validate": "newData.isNumber() && newData.val() >= -3 && newData.val() <= 3"
+          },
+          "postContent": {
+            ".validate": "!newData.exists() || (newData.isString() && newData.val().length <= 600)"
           },
           "timestamp": {
             ".validate": "!data.exists() || data.val() === newData.val()"
@@ -131,21 +143,20 @@
             "timestamp"
           ],
           ".read": true,
-          ".write": false,
           "$subreply_id": {
-            ".write": "auth != null && ( (!data.exists() && newData.parent().parent().parent().parent().child('users/' + auth.uid + '/subreplies/' + $post_id + '/' + $reply_id + '/' + $subreply_id).exists()) || (data.exists() && (data.child('userId').val() === auth.uid || root.child('users/' + auth.uid + '/subreplies/' + $post_id + '/' + $reply_id + '/' + $subreply_id).exists()) && (!newData.exists() ? !newData.parent().parent().parent().parent().child('users/' + auth.uid + '/subreplies/' + $post_id + '/' + $reply_id + '/' + $subreply_id).exists() : true)) )",
+            ".write": "auth != null && ( (!data.exists() && newData.parent().parent().parent().parent().child('authorLookup').child($subreply_id).child('uid').val() === auth.uid && newData.parent().parent().parent().parent().child('users').child(auth.uid).child('subreplies').child($post_id).child($reply_id).child($subreply_id).exists()) || (data.exists() && root.child('authorLookup').child($subreply_id).child('uid').val() === auth.uid && (!newData.exists() ? !newData.parent().parent().parent().parent().child('authorLookup').child($subreply_id).exists() && !newData.parent().parent().parent().parent().child('users').child(auth.uid).child('subreplies').child($post_id).child($reply_id).child($subreply_id).exists() : true)) )",
             ".validate": "!newData.exists() || (data.exists() || newData.hasChildren(['id', 'postContent', 'timestamp', 'parentPostId', 'parentReplyId', 'authorDisplay']))",
             "id": {
-              ".validate": "!newData.exists() || (newData.isString() && newData.val() === $subreply_id)"
+              ".validate": "!newData.exists() || (newData.val() === $subreply_id && (!data.exists() || data.val() === newData.val()))"
+            },
+            "userId": {
+              ".validate": "!newData.exists()"
             },
             "parentReplyId": {
-              ".validate": "!newData.exists() || (newData.isString() && newData.val() === $reply_id)"
+              ".validate": "!newData.exists() || newData.val() === $reply_id"
             },
             "parentPostId": {
               ".validate": "!newData.exists() || newData.val() === $post_id"
-            },
-            "userId": {
-              ".validate": "!newData.exists() || newData.val() === auth.uid"
             },
             "authorDisplay": {
               ".validate": "newData.isString() && newData.val().length <= 100"

--- a/database.rules.json
+++ b/database.rules.json
@@ -108,7 +108,7 @@
         ".read": true,
         "$reply_id": {
           ".write": "auth != null && ( (!data.exists() && newData.parent().parent().parent().child('authorLookup').child($reply_id).child('uid').val() === auth.uid && newData.parent().parent().parent().child('users').child(auth.uid).child('replies').child($post_id).child($reply_id).exists()) || (data.exists() && root.child('authorLookup').child($reply_id).child('uid').val() === auth.uid && (!newData.exists() ? !newData.parent().parent().parent().child('authorLookup').child($reply_id).exists() && !newData.parent().parent().parent().child('users').child(auth.uid).child('replies').child($post_id).child($reply_id).exists() : true)) )",
-          ".validate": "!newData.exists() || (data.exists() || newData.hasChildren(['postContent', 'timestamp', 'parentPostId', 'interactionScore', 'replyCount']))",
+          ".validate": "!newData.exists() || (data.exists() || newData.hasChildren(['postContent', 'timestamp', 'parentPostId', 'interactionScore', 'replyCount', 'authorDisplay']))",
           "id": {
             ".validate": "!newData.exists() || (newData.val() === $reply_id && (!data.exists() || data.val() === newData.val()))"
           },
@@ -120,6 +120,12 @@
           },
           "replyCount": {
             ".validate": "!data.exists() ? newData.val() == 0 : newData.val() == data.val()"
+          },
+          "authorDisplay": {
+            ".validate": "newData.isString() && newData.val().length <= 100 && (root.child('authorLookup').child($post_id).child('uid').val() !== auth.uid || newData.val() === root.child('posts').child($post_id).child('authorDisplay').val())"
+          },
+          "isThreadAuthor": {
+            ".validate": "!newData.exists() || (newData.isBoolean() && newData.val() === (root.child('authorLookup').child($post_id).child('uid').val() === auth.uid))"
           },
           "interactionScore": {
             ".validate": "newData.isNumber() && newData.val() >= -3 && newData.val() <= 3"
@@ -159,7 +165,10 @@
               ".validate": "!newData.exists() || newData.val() === $post_id"
             },
             "authorDisplay": {
-              ".validate": "newData.isString() && newData.val().length <= 100"
+              ".validate": "newData.isString() && newData.val().length <= 100 && (root.child('authorLookup').child($post_id).child('uid').val() !== auth.uid || newData.val() === root.child('posts').child($post_id).child('authorDisplay').val())"
+            },
+            "isThreadAuthor": {
+              ".validate": "!newData.exists() || (newData.isBoolean() && newData.val() === (root.child('authorLookup').child($post_id).child('uid').val() === auth.uid))"
             },
             "postContent": {
               ".validate": "!newData.exists() || (newData.isString() && newData.val().length <= 600)"

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -31,29 +31,35 @@ const escapeHtml = (unsafe: string) => {
     .replace(/'/g, "&#039;");
 };
 
+/** * Helper: Fetches the metadata from authorLookup to find the owner
+ * and the exact path of any content ID.
+ */
+const getLookupData = async (id: string) => {
+  const snap = await admin.database().ref(`authorLookup/${id}`).once("value");
+  return snap.exists() ? snap.val() : null;
+};
+
 /**
- * Resolves an ID to its correct database reference by checking both posts and replies.
- * @param {string} id - The postId or replyId to find.
- * @param {string|null} [providedParentId] - Optional parentId to skip the search and generate path directly.
- * @return {Promise<any>} The database reference for the given ID.
+ * Uses authorLookup routing data to return a direct reference.
+ * No more searching/fallback required.
  */
 const getContentRef = async (
   id: string,
-  providedParentId?: string | null,
 ): Promise<admin.database.Reference | null> => {
+  const meta = await getLookupData(id);
+  if (!meta) return null;
+
   const db = admin.database();
-
-  // 1. use provided parentId if available
-  if (providedParentId && providedParentId !== "top") {
-    return db.ref(`replies/${providedParentId}/${id}`);
+  switch (meta.type) {
+    case "post":
+      return db.ref(`posts/${id}`);
+    case "reply":
+      return db.ref(`replies/${meta.postId}/${id}`);
+    case "subreply":
+      return db.ref(`subreplies/${meta.postId}/${meta.replyId}/${id}`);
+    default:
+      return null;
   }
-
-  // 3. fallback to posts
-  const postRef = db.ref(`posts/${id}`);
-  const postSnap = await postRef.once("value");
-  if (postSnap.exists()) return postRef;
-
-  return null;
 };
 
 // delete replies in batches to avoid thundering herd
@@ -201,55 +207,67 @@ export const beforesignedin = beforeUserSignedIn((event) => {
 
 /**
  * Cleanup for top-level posts.
- * Only triggers when a post is removed.
  */
 export const onPostDeletedCleanup = onValueDeleted(
   "/posts/{postId}",
   async (event) => {
     const { postId } = event.params;
-    const postData = event.data.val();
     const db = admin.database();
 
+    // Clean up author lookup
+    await db.ref(`authorLookup/${postId}`).remove();
+
+    const postData = event.data.val();
     if (!postData) return;
 
-    const replyCount = postData.replyCount || 0;
-
-    if (replyCount < 100) {
-      // Small post: Safe to delete all at once
+    if ((postData.replyCount || 0) < 100) {
       await db.ref(`replies/${postId}`).remove();
     } else {
-      // Large post: delete in chunks to avoid overwhelming the system
       await deleteRepliesInBatches(postId);
     }
   },
 );
 
 /**
+ * Cleanup for sub-replies (Added this trigger for completeness)
+ */
+export const onSubReplyDeletedCleanup = onValueDeleted(
+  "/subreplies/{postId}/{replyId}/{subReplyId}",
+  async (event) => {
+    const { postId, replyId, subReplyId } = event.params;
+    const db = admin.database();
+
+    const meta = await getLookupData(subReplyId);
+    if (meta) {
+      const updates: Record<string, null> = {};
+      updates[`authorLookup/${subReplyId}`] = null;
+      updates[
+        `users/${meta.uid}/subreplies/${postId}/${replyId}/${subReplyId}`
+      ] = null;
+      await db.ref().update(updates);
+    }
+  },
+);
+
+/**
  * Cleanup for individual replies.
- * Only triggers when a reply is removed (manually or via cascade).
  */
 export const onReplyDeletedCleanup = onValueDeleted(
   "/replies/{parentId}/{replyId}",
   async (event) => {
     const { parentId, replyId } = event.params;
-    const replyData = event.data.val();
-    if (!replyData) return;
-
     const db = admin.database();
-    const updates: Record<string, null> = {};
 
-    // if the post was made non-anonymously, clean up the user receipt.
-    // otherwise, it'll be cleaned up later. dangling pointer is self-deleted on
-    // read to avoid performance overhead of doing it automatically.
-    if (replyData?.userId) {
-      updates[`users/${replyData.userId}/replies/${parentId}/${replyId}`] =
-        null;
+    const meta = await getLookupData(replyId);
+
+    const updates: Record<string, null> = {};
+    if (meta) {
+      updates[`authorLookup/${replyId}`] = null;
+      updates[`users/${meta.uid}/replies/${parentId}/${replyId}`] = null;
     }
 
-    // cascade: remove all sub-replies for this reply.
-    // each deletion fires onSubReplyWritten + onSubReplyDeletedCleanup
-    // to handle hasSubReply and user receipt cleanup automatically.
-    await db.ref(`subreplies/${parentId}/${replyId}`).remove();
+    // Instead of a separate .remove(), just add it to the atomic update
+    updates[`subreplies/${parentId}/${replyId}`] = null;
 
     return db.ref().update(updates);
   },
@@ -381,63 +399,44 @@ export const onReplyCreatedNotification = onValueCreated(
     const replyData = event.data.val();
     const db = admin.database();
 
-    if (!replyData || !replyData.userId) return null;
+    if (!replyData) return null;
 
     try {
-      // find the owner of the content being replied to
-      const parentRef = await getContentRef(parentId);
-      if (!parentRef) {
-        console.warn(
-          `Parent content ${parentId} not found. Skipping notification.`,
-        );
-        return null;
-      }
+      // Get the author of the NEW reply
+      const replyMeta = await getLookupData(replyId);
+      const replyAuthorId = replyMeta?.uid;
 
-      const parentSnap = await parentRef.once("value");
-      const parentData = parentSnap.val();
-      const ownerId = parentData?.userId;
+      // Get the author of the PARENT content (Post or Reply)
+      const parentMeta = await getLookupData(parentId);
+      const ownerId = parentMeta?.uid;
 
-      // don't notify if the user is replying to their own content
-      if (!ownerId || ownerId === replyData.userId) return null;
+      // Don't notify if parent doesn't exist or user is replying to self
+      if (!ownerId || ownerId === replyAuthorId) return null;
 
-      // define the path for the notification
-      // We use parentId (the post being replied to) as the notification ID for aggregation
       const notifRef = db.ref(`users/${ownerId}/notifications/${parentId}`);
-
       const now = Date.now();
 
       return notifRef.transaction((current) => {
-        if (current) {
-          // If notification exists, increment count and mark as unread
-          return {
-            ...current,
-            count: (current.count || 1) + 1,
-            latestReplyId: replyId,
-            isRead: false,
-            updatedAt: now,
-          };
-        } else {
-          // Create new notification
-          return {
-            type: "reply",
-            count: 1,
-            latestReplyId: replyId,
-            isRead: false,
-            createdAt: now,
-            updatedAt: now,
-          };
-        }
+        const base = current || {
+          type: "reply",
+          count: 0,
+          createdAt: now,
+          isRead: false,
+        };
+        return {
+          ...base,
+          count: base.count + 1,
+          latestReplyId: replyId,
+          isRead: false,
+          updatedAt: now,
+        };
       });
     } catch (error) {
-      console.error(`Notification trigger failed for reply ${replyId}:`, error);
+      console.error(`Notification failed for reply ${replyId}:`, error);
       return null;
     }
   },
 );
-
-// TODO:: currently notifications are only sent on non-anonymous posts/replies.
-// there would be high performance overhead for enabling it for anonymous posts
-// too (doesn't scale well). Is there a good compromise?
 
 /**
  * Automatically creates or updates a notification for the direct reply owner
@@ -446,56 +445,40 @@ export const onReplyCreatedNotification = onValueCreated(
 export const onSubReplyCreatedNotification = onValueCreated(
   "/subreplies/{rootPostId}/{parentReplyId}/{subReplyId}",
   async (event) => {
-    const { rootPostId, parentReplyId, subReplyId } = event.params;
-    const subReplyData = event.data.val();
+    const { parentReplyId, subReplyId } = event.params;
     const db = admin.database();
 
-    // only send notifications for non-anonymous sub-replies
-    if (!subReplyData || !subReplyData.userId) return null;
-
     try {
-      // find the owner of the direct reply being replied to
-      const parentReplySnap = await db
-        .ref(`replies/${rootPostId}/${parentReplyId}`)
-        .once("value");
-      const parentReplyData = parentReplySnap.val();
-      const ownerId = parentReplyData?.userId;
+      const subReplyMeta = await getLookupData(subReplyId);
+      const parentReplyMeta = await getLookupData(parentReplyId);
 
-      // don't notify if the user is replying to their own reply
-      if (!ownerId || ownerId === subReplyData.userId) return null;
+      const replyAuthorId = subReplyMeta?.uid;
+      const ownerId = parentReplyMeta?.uid;
 
-      // aggregate under the parentReplyId so notifications for the same reply
-      // are grouped together (same pattern as post reply notifications)
+      if (!ownerId || ownerId === replyAuthorId) return null;
+
       const notifRef = db.ref(
         `users/${ownerId}/notifications/${parentReplyId}`,
       );
       const now = Date.now();
 
       return notifRef.transaction((current) => {
-        if (current) {
-          return {
-            ...current,
-            count: (current.count || 1) + 1,
-            latestReplyId: subReplyId,
-            isRead: false,
-            updatedAt: now,
-          };
-        } else {
-          return {
-            type: "reply",
-            count: 1,
-            latestReplyId: subReplyId,
-            isRead: false,
-            createdAt: now,
-            updatedAt: now,
-          };
-        }
+        const base = current || {
+          type: "reply",
+          count: 0,
+          createdAt: now,
+          isRead: false,
+        };
+        return {
+          ...base,
+          count: base.count + 1,
+          latestReplyId: subReplyId,
+          isRead: false,
+          updatedAt: now,
+        };
       });
     } catch (error) {
-      console.error(
-        `Notification trigger failed for sub-reply ${subReplyId}:`,
-        error,
-      );
+      console.error(`Notification failed for sub-reply ${subReplyId}:`, error);
       return null;
     }
   },

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -277,15 +277,15 @@ export const onReplyDeletedCleanup = onValueDeleted(
  * Manages the subReplyCount counter on parent reply when sub-replies are created or deleted.
  */
 export const updateSubReplyCount = onValueWritten(
-  "/subreplies/{rootPostId}/{parentReplyId}/{subReplyId}",
+  "/subreplies/{parentPostId}/{parentReplyId}/{subReplyId}",
   async (event) => {
-    const { rootPostId, parentReplyId } = event.params;
+    const { parentPostId, parentReplyId } = event.params;
     const db = admin.database();
 
     const created = event.data.after.exists() && !event.data.before.exists();
     const deleted = !event.data.after.exists() && event.data.before.exists();
 
-    const parentReplyRef = db.ref(`replies/${rootPostId}/${parentReplyId}`);
+    const parentReplyRef = db.ref(`replies/${parentPostId}/${parentReplyId}`);
     return syncReplyCount(parentReplyRef, created, deleted, parentReplyId);
   },
 );
@@ -443,7 +443,7 @@ export const onReplyCreatedNotification = onValueCreated(
  * when a new sub-reply is created.
  */
 export const onSubReplyCreatedNotification = onValueCreated(
-  "/subreplies/{rootPostId}/{parentReplyId}/{subReplyId}",
+  "/subreplies/{parentPostId}/{parentReplyId}/{subReplyId}",
   async (event) => {
     const { parentReplyId, subReplyId } = event.params;
     const db = admin.database();

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test:rules:vitest": "vitest run tests/",
-    "test:rules": "firebase emulators:exec --only database,auth --project=the-open-dissent-prod \"pnpm test:rules:vitest\"",
-    "test": "pnpm test:rules",
+    "test:all": "vitest run tests/",
+    "test": "firebase emulators:exec --only database,auth --project=the-open-dissent-prod \"pnpm test:vitest\"",
+    "test:rules": "firebase emulators:exec --only database,auth --project=the-open-dissent-prod \"vitest run tests/database.rules.test.ts\"",
+    "test:integration": "firebase emulators:exec --only database,auth --project=the-open-dissent-prod \"vitest run tests/integration.test.ts\"",
     "functions:watch": "npm run --prefix functions build:watch",
     "emulate:new": "firebase emulators:start --project=the-open-dissent-prod --export-on-exit=./firebase-data",
     "emulate": "firebase emulators:start --project=the-open-dissent-prod --import=./firebase-data --export-on-exit=./firebase-data"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test:rules:vitest": "vitest run tests/database.rules.test.ts",
+    "test:rules:vitest": "vitest run tests/",
     "test:rules": "firebase emulators:exec --only database,auth --project=the-open-dissent-prod \"pnpm test:rules:vitest\"",
     "test": "pnpm test:rules",
     "functions:watch": "npm run --prefix functions build:watch",

--- a/scripts/migrate-author-lookup.cjs
+++ b/scripts/migrate-author-lookup.cjs
@@ -1,0 +1,315 @@
+/**
+ * One-time migration script for the authorLookup table.
+ *
+ * What it does:
+ *   1. Reads all posts/, replies/, and subreplies/ nodes.
+ *   2. For every content node that still has a `userId` field:
+ *      a. Creates an `authorLookup/{id}` entry (if missing).
+ *      b. Removes `userId` from the content node.
+ *      c. Also strips any other legacy fields (content, likes, etc.).
+ *   3. Backfills `authorDisplay` as "Anonymous User" on any node missing it.
+ *   4. Commits everything in a single multi-path update.
+ *
+ * Safety:
+ *   - Runs in DRY-RUN mode by default. Pass `--commit` to actually write.
+ *   - Logs every planned change for review before committing.
+ *
+ * Usage:
+ *   node scripts/migrate-author-lookup.cjs              # dry run
+ *   node scripts/migrate-author-lookup.cjs --commit      # write to DB
+ *
+ * Prerequisites:
+ *   - Place your service-account.json in the project root (or scripts/ dir).
+ *   - npm install firebase-admin (or use the one from functions/).
+ */
+
+const admin = require("firebase-admin");
+const path = require("path");
+
+// --- Configuration -----------------------------------------------------------
+
+// Try loading service account from project root, then scripts dir
+let serviceAccount;
+try {
+  serviceAccount = require(path.resolve(__dirname, "../service-account.json"));
+} catch {
+  try {
+    serviceAccount = require(path.resolve(__dirname, "./service-account.json"));
+  } catch {
+    console.error(
+      "ERROR: Could not find service-account.json in project root or scripts/ dir.",
+    );
+    console.error(
+      "   Download it from Firebase Console > Project Settings > Service Accounts.",
+    );
+    process.exit(1);
+  }
+}
+
+// UPDATE THIS to match your production database URL
+const DATABASE_URL =
+  "https://the-open-dissent-prod-default-rtdb.firebaseio.com";
+
+// Legacy fields that should not exist on content nodes (will be removed)
+const LEGACY_FIELDS_TO_STRIP = ["userId", "content", "likes", "dislikes"];
+
+// --- Init --------------------------------------------------------------------
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: DATABASE_URL,
+});
+
+const db = admin.database();
+const DRY_RUN = !process.argv.includes("--commit");
+
+// --- Helpers -----------------------------------------------------------------
+
+const stats = {
+  postsScanned: 0,
+  repliesScanned: 0,
+  subRepliesScanned: 0,
+  lookupCreated: 0,
+  fieldsStripped: 0,
+  displayBackfilled: 0,
+  alreadyClean: 0,
+  orphaned: 0,
+};
+
+/**
+ * Process a single content node. Returns the update entries (if any).
+ */
+function processNode(id, data, type, context = {}) {
+  const updates = {};
+  let touched = false;
+
+  // 1. Create authorLookup entry if missing (requires userId to exist)
+  //    If userId is missing AND there's no authorLookup, we can't create one.
+  if (data.userId) {
+    const lookupEntry = { uid: data.userId, type };
+    if (type === "reply" && context.postId) {
+      lookupEntry.postId = context.postId;
+    } else if (type === "subreply" && context.postId && context.replyId) {
+      lookupEntry.postId = context.postId;
+      lookupEntry.replyId = context.replyId;
+    }
+
+    updates[`authorLookup/${id}`] = lookupEntry;
+    stats.lookupCreated++;
+    touched = true;
+
+    // Also ensure the user receipt exists
+    if (type === "post") {
+      updates[`users/${data.userId}/posts/${id}`] = true;
+    } else if (type === "reply" && context.postId) {
+      updates[`users/${data.userId}/replies/${context.postId}/${id}`] = true;
+    } else if (type === "subreply" && context.postId && context.replyId) {
+      updates[
+        `users/${data.userId}/subreplies/${context.postId}/${context.replyId}/${id}`
+      ] = true;
+    }
+  }
+
+  // 2. Strip legacy fields from the content node
+  const contentPath =
+    type === "post"
+      ? `posts/${id}`
+      : type === "reply"
+        ? `replies/${context.postId}/${id}`
+        : `subreplies/${context.postId}/${context.replyId}/${id}`;
+
+  for (const field of LEGACY_FIELDS_TO_STRIP) {
+    if (data[field] !== undefined) {
+      updates[`${contentPath}/${field}`] = null;
+      stats.fieldsStripped++;
+      touched = true;
+    }
+  }
+
+  // 3. Backfill authorDisplay if missing (assume all legacy posts are anonymous)
+  if (!data.authorDisplay) {
+    updates[`${contentPath}/authorDisplay`] = "Anonymous User";
+    stats.displayBackfilled++;
+    touched = true;
+  }
+
+  if (!touched) {
+    stats.alreadyClean++;
+  }
+
+  return updates;
+}
+
+// --- Main migration ----------------------------------------------------------
+
+async function migrate() {
+  console.log("Starting authorLookup migration...");
+  console.log(
+    `   Mode: ${DRY_RUN ? "DRY RUN (pass --commit to write)" : "LIVE COMMIT"}`,
+  );
+  console.log(`   Database: ${DATABASE_URL}`);
+  console.log("");
+
+  const allUpdates = {};
+
+  try {
+    // ---- Posts ----
+    console.log("Fetching posts...");
+    const postsSnap = await db.ref("posts").once("value");
+    postsSnap.forEach((snap) => {
+      const id = snap.key;
+      const data = snap.val();
+      stats.postsScanned++;
+
+      if (!data || typeof data !== "object") return;
+
+      const updates = processNode(id, data, "post");
+      Object.assign(allUpdates, updates);
+    });
+    console.log(`   Scanned ${stats.postsScanned} posts`);
+
+    // ---- Replies ----
+    console.log("Fetching replies...");
+    const repliesSnap = await db.ref("replies").once("value");
+    repliesSnap.forEach((parentSnap) => {
+      const postId = parentSnap.key;
+      parentSnap.forEach((replySnap) => {
+        const replyId = replySnap.key;
+        const data = replySnap.val();
+        stats.repliesScanned++;
+
+        if (!data || typeof data !== "object") return;
+
+        const updates = processNode(replyId, data, "reply", { postId });
+        Object.assign(allUpdates, updates);
+      });
+    });
+    console.log(`   Scanned ${stats.repliesScanned} replies`);
+
+    // ---- Sub-Replies ----
+    console.log("Fetching subreplies...");
+    const subRepliesSnap = await db.ref("subreplies").once("value");
+    if (subRepliesSnap.exists()) {
+      subRepliesSnap.forEach((postSnap) => {
+        const postId = postSnap.key;
+        postSnap.forEach((replySnap) => {
+          const replyId = replySnap.key;
+          replySnap.forEach((subSnap) => {
+            const subId = subSnap.key;
+            const data = subSnap.val();
+            stats.subRepliesScanned++;
+
+            if (!data || typeof data !== "object") return;
+
+            const updates = processNode(subId, data, "subreply", {
+              postId,
+              replyId,
+            });
+            Object.assign(allUpdates, updates);
+          });
+        });
+      });
+    }
+    console.log(`   Scanned ${stats.subRepliesScanned} subreplies`);
+
+    // ---- Check existing authorLookup for orphaned entries ----
+    console.log("Checking existing authorLookup for orphans...");
+    const lookupSnap = await db.ref("authorLookup").once("value");
+    if (lookupSnap.exists()) {
+      const existingLookups = lookupSnap.val();
+      for (const [id, meta] of Object.entries(existingLookups)) {
+        // Skip entries we're about to create/overwrite
+        if (allUpdates[`authorLookup/${id}`]) continue;
+
+        // Check if the content still exists
+        let contentPath;
+        if (meta.type === "post") contentPath = `posts/${id}`;
+        else if (meta.type === "reply")
+          contentPath = `replies/${meta.postId}/${id}`;
+        else if (meta.type === "subreply")
+          contentPath = `subreplies/${meta.postId}/${meta.replyId}/${id}`;
+
+        if (contentPath) {
+          const exists = await db.ref(contentPath).once("value");
+          if (!exists.exists()) {
+            console.warn(`   WARNING: Orphaned authorLookup/${id} (content missing)`);
+            allUpdates[`authorLookup/${id}`] = null;
+            stats.orphaned++;
+          }
+        }
+      }
+    }
+
+    // ---- Summary ----
+    const updateCount = Object.keys(allUpdates).length;
+    console.log("");
+    console.log("Migration Summary:");
+    console.log(`   Posts scanned:              ${stats.postsScanned}`);
+    console.log(`   Replies scanned:            ${stats.repliesScanned}`);
+    console.log(`   Sub-replies scanned:        ${stats.subRepliesScanned}`);
+    console.log(`   Lookup entries to create:   ${stats.lookupCreated}`);
+    console.log(`   Legacy fields to strip:     ${stats.fieldsStripped}`);
+    console.log(`   authorDisplay backfilled:   ${stats.displayBackfilled}`);
+    console.log(`   Already clean:              ${stats.alreadyClean}`);
+    console.log(`   Orphaned lookups to remove: ${stats.orphaned}`);
+    console.log(`   Total DB updates:           ${updateCount}`);
+    console.log("");
+
+    if (updateCount === 0) {
+      console.log("Database is already fully migrated. Nothing to do.");
+      return;
+    }
+
+    // ---- Preview ----
+    if (DRY_RUN) {
+      console.log("Planned updates (first 50):");
+      const entries = Object.entries(allUpdates);
+      entries.slice(0, 50).forEach(([path, value]) => {
+        if (value === null) {
+          console.log(`   DELETE  ${path}`);
+        } else if (typeof value === "object") {
+          console.log(`   SET     ${path} = ${JSON.stringify(value)}`);
+        } else {
+          console.log(`   SET     ${path} = ${value}`);
+        }
+      });
+      if (entries.length > 50) {
+        console.log(`   ... and ${entries.length - 50} more`);
+      }
+      console.log("");
+      console.log("This was a DRY RUN. Run with --commit to apply changes.");
+      return;
+    }
+
+    // ---- Commit ----
+    // Firebase multi-path updates are limited to ~10k paths.
+    // If we have more, batch them.
+    const BATCH_SIZE = 5000;
+    const entries = Object.entries(allUpdates);
+
+    if (entries.length <= BATCH_SIZE) {
+      console.log("Writing all updates in a single batch...");
+      await db.ref().update(allUpdates);
+    } else {
+      const totalBatches = Math.ceil(entries.length / BATCH_SIZE);
+      for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+        const batch = Object.fromEntries(entries.slice(i, i + BATCH_SIZE));
+        const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+        console.log(
+          `Writing batch ${batchNum}/${totalBatches} (${Object.keys(batch).length} updates)...`,
+        );
+        await db.ref().update(batch);
+        // Breathe between batches
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+
+    console.log("Migration complete!");
+  } catch (error) {
+    console.error("Migration failed:", error);
+  } finally {
+    process.exit();
+  }
+}
+
+migrate();

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,2160 @@
+{
+  "name": "theopendissent-migration",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "theopendissent-migration",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "firebase-admin": "^13.6.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.4",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/firebase-admin": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.4.0",
+        "uuid": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "theopendissent-migration",
+  "version": "1.0.0",
+  "description": "",
+  "main": "migrate.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "firebase-admin": "^13.6.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function Layout() {
 
   const [activeTarget, setActiveTarget] = useState<{
     id: string;
-    parentId: string;
+    parentId?: string;
   } | null>(null);
 
   const [isInitialCheck, setIsInitialCheck] = useState(true);

--- a/src/components/feed/ComposeModal.tsx
+++ b/src/components/feed/ComposeModal.tsx
@@ -16,7 +16,8 @@ interface ComposeModalProps {
   parentPost?: Post | null;
   /** set when composing a sub-reply — the direct reply being responded to */
   parentReply?: Post | null;
-  onSuccess?: (newId: string, parentId: string) => void;
+  /** called when the Post is successfully created */
+  onSuccess?: (newId: string, parentId?: string) => void;
 }
 
 export const ComposeModal = ({
@@ -99,9 +100,9 @@ export const ComposeModal = ({
 
           if (newKey) {
             pinPostToTop(newKey);
-            // Pass BOTH the new ID and the Parent ID
-            if (parentReply && onSuccess) {
-              onSuccess(newKey, parentReply.id);
+            // Pass the new ID and Parent ID (if any) to trigger auto-scrolling
+            if (onSuccess) {
+              onSuccess(newKey, parentReply?.id || parentPost?.id);
             }
             // Navigate to root feed if a top-level post was created from elsewhere (e.g. profile page)
             if (!isReply && location.pathname !== "/") {

--- a/src/components/feed/ComposeModal.tsx
+++ b/src/components/feed/ComposeModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Post } from "../../types";
 import { useAuth } from "../../context/AuthContext";
@@ -28,6 +29,8 @@ export const ComposeModal = ({
   const { user } = useAuth();
   const { openModal, closeModal } = useModal();
   const ownedPosts = useOwnedPosts();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [content, setContent] = useState("");
   const [score, setScore] = useState(0);
@@ -99,6 +102,10 @@ export const ComposeModal = ({
             // Pass BOTH the new ID and the Parent ID
             if (parentReply && onSuccess) {
               onSuccess(newKey, parentReply.id);
+            }
+            // Navigate to root feed if a top-level post was created from elsewhere (e.g. profile page)
+            if (!isReply && location.pathname !== "/") {
+              navigate("/");
             }
           }
 

--- a/src/components/feed/ComposeModal.tsx
+++ b/src/components/feed/ComposeModal.tsx
@@ -92,7 +92,6 @@ export const ComposeModal = ({
             parentReplyId: parentReply?.id,
             score: isReply && !isSubReply ? score : undefined,
             isThreadAuthor,
-            includePublicUserId: !isAnonymous,
           });
 
           if (newKey) {

--- a/src/components/feed/FeedContainer.tsx
+++ b/src/components/feed/FeedContainer.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { usePosts } from "../../hooks/usePosts";
+import { usePosts, clearPinnedPosts } from "../../hooks/usePosts";
 import { useFeedSort } from "../../context/FeedSortContext";
 import { getPostById } from "../../lib/firebase";
 import { Post } from "../../types";
 import { FeedList } from "./FeedList";
+import { useOutletContext } from "react-router-dom";
 
 /**
  * Smart container: Orchestrates data fetching, deep-linking, and sorting logic.
@@ -12,6 +13,26 @@ export const FeedContainer = () => {
   const { sortType } = useFeedSort();
   const { posts, loading, loadMore, currentLimit } = usePosts(20, sortType);
   const [highlightedPost, setHighlightedPost] = useState<Post | null>(null);
+  const { activeTarget, setActiveTarget }: any = useOutletContext();
+
+  // handle auto-scrolling to newly created top-level posts
+  useEffect(() => {
+    if (activeTarget && !activeTarget.parentId) {
+      const timer = setTimeout(() => {
+        const el = document.getElementById(`post-${activeTarget.id}`);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          setActiveTarget(null);
+        }
+      }, 400);
+      return () => clearTimeout(timer);
+    }
+  }, [activeTarget, setActiveTarget]);
+
+  // clear pinned posts when unmounting
+  useEffect(() => {
+    return () => clearPinnedPosts();
+  }, []);
 
   // reset scroll position when the user changes the sort order
   useEffect(() => {
@@ -72,7 +93,6 @@ export const FeedContainer = () => {
       loading={loading}
       hasMore={hasMore}
       onLoadMore={handleLoadMore}
-      sortKey={sortType}
     />
   );
 };

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -15,7 +15,6 @@ interface FeedItemProps {
   isReply?: boolean;
   highlighted?: boolean;
   disableClick?: boolean;
-  threadAuthorUserId?: string;
   /** called when the Replies button is tapped on a reply card (opens sub-reply compose) */
   onReply?: () => void;
 }
@@ -26,10 +25,9 @@ export const FeedItem = memo(
     isReply = false,
     highlighted = false,
     disableClick = false,
-    threadAuthorUserId,
     onReply,
   }: FeedItemProps) => {
-    if (!item || (!item.userId && !item.authorDisplay)) return null;
+    if (!item) return null;
 
     const navigate = useNavigate();
     const { sharePost } = useShare();
@@ -48,16 +46,8 @@ export const FeedItem = memo(
     } = usePostActions(item);
 
     const ownedPosts = useOwnedPosts();
-    const isOwner =
-      (item.userId && uid === item.userId) || ownedPosts.has(item.id);
-    const isThreadAuthor =
-      item.isThreadAuthor ??
-      Boolean(
-        isReply &&
-        item.userId &&
-        threadAuthorUserId &&
-        item.userId === threadAuthorUserId,
-      );
+    const isOwner = ownedPosts.has(item.id);
+    const isThreadAuthor = item.isThreadAuthor ?? false;
 
     const charsLeft = 600 - editContent.length;
     const isNearLimit = charsLeft < 50;

--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -12,7 +12,6 @@ interface FeedListProps {
   loading: boolean;
   hasMore: boolean;
   onLoadMore: () => void;
-  sortKey: string;
 }
 
 export const FeedList = ({
@@ -21,7 +20,6 @@ export const FeedList = ({
   loading,
   hasMore,
   onLoadMore,
-  sortKey,
 }: FeedListProps) => {
   const bottomBoundaryRef = useInfiniteScroll({
     loading,
@@ -63,45 +61,58 @@ export const FeedList = ({
 
   return (
     <div className="flex flex-col w-full max-w-2xl mx-auto gap-3 min-h-100">
-      <AnimatePresence mode="wait">
-        {loading && showLoadingUI && posts.length === 0 ? (
-          <motion.div
-            key="loading-skeletons"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="flex flex-col gap-3"
-          >
-            {[1, 2, 3, 4].map((i) => (
-              <FeedItemSkeleton key={i} />
-            ))}
-          </motion.div>
-        ) : (
-          <motion.div
-            key={sortKey}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -10 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
-            className="flex flex-col gap-3"
-          >
-            {highlightedPost && (
-              <FeedItem
-                item={highlightedPost}
-                highlighted={true}
-                isReply={!!highlightedPost.parentPostId}
-              />
+      <div className="flex flex-col gap-3 w-full">
+        <AnimatePresence mode="popLayout">
+          {loading && showLoadingUI && posts.length === 0 && (
+            <motion.div
+              key="loading-skeletons"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="flex flex-col gap-3"
+            >
+              {[1, 2, 3, 4].map((i) => (
+                <FeedItemSkeleton key={i} />
+              ))}
+            </motion.div>
+          )}
+
+          {!(loading && showLoadingUI && posts.length === 0) &&
+            highlightedPost && (
+              <motion.div
+                layout
+                key={`highlight-${highlightedPost.id}`}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={{ duration: 0.3, ease: "easeOut" }}
+                className="w-full"
+              >
+                <FeedItem
+                  item={highlightedPost}
+                  highlighted={true}
+                  isReply={!!highlightedPost.parentPostId}
+                />
+              </motion.div>
             )}
-            {posts.map((post) => (
-              <FeedItem
+
+          {!(loading && showLoadingUI && posts.length === 0) &&
+            posts.map((post) => (
+              <motion.div
+                layout
                 key={post.id}
-                item={post}
-                isReply={!!post.parentPostId}
-              />
+                id={`post-${post.id}`}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={{ duration: 0.3, ease: "easeOut" }}
+                className="w-full"
+              >
+                <FeedItem item={post} isReply={!!post.parentPostId} />
+              </motion.div>
             ))}
-          </motion.div>
-        )}
-      </AnimatePresence>
+        </AnimatePresence>
+      </div>
 
       {/* Bottom Boundary / Infinite Scroll Loader */}
       <div

--- a/src/components/feed/SubReplyThread.tsx
+++ b/src/components/feed/SubReplyThread.tsx
@@ -197,7 +197,6 @@ export const SubReplyThread = ({
                             isReply={true}
                             // Pass the highlighted state
                             highlighted={sr.id === targetSubReplyId}
-                            threadAuthorUserId={parentReply.userId}
                             onReply={onReply}
                           />
                         </motion.div>

--- a/src/context/OwnedPostsContext.tsx
+++ b/src/context/OwnedPostsContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
 import { ref, onValue } from "firebase/database";
 import { db } from "../lib/firebase";
 import { useAuth } from "./AuthContext";
@@ -15,18 +21,22 @@ export const OwnedPostsProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
 
-    const postsRef = ref(db, `users/${user.uid}/posts`);
-    const repliesRef = ref(db, `users/${user.uid}/replies`);
-    const subRepliesRef = ref(db, `users/${user.uid}/subreplies`);
+    const userPath = `users/${user.uid}`;
+    const postsRef = ref(db, `${userPath}/posts`);
+    const repliesRef = ref(db, `${userPath}/replies`);
+    const subRepliesRef = ref(db, `${userPath}/subreplies`);
 
     let currentPosts: string[] = [];
     let currentReplies: string[] = [];
     let currentSubReplies: string[] = [];
 
     const updateSet = () => {
-      setOwnedIds(new Set([...currentPosts, ...currentReplies, ...currentSubReplies]));
+      setOwnedIds(
+        new Set([...currentPosts, ...currentReplies, ...currentSubReplies]),
+      );
     };
 
+    // posts receipt is 1-level: postId -> true
     const postsUnsub = onValue(postsRef, (snap) => {
       const keys: string[] = [];
       snap.forEach((child) => {
@@ -36,24 +46,25 @@ export const OwnedPostsProvider = ({ children }: { children: ReactNode }) => {
       updateSet();
     });
 
+    // replies receipt is 2-level: parentId -> replyId -> true
     const repliesUnsub = onValue(repliesRef, (snap) => {
       const keys: string[] = [];
-      snap.forEach((parent) => {
-        parent.forEach((child) => {
-          keys.push(child.key as string);
+      snap.forEach((parentPostSnap) => {
+        parentPostSnap.forEach((replySnap) => {
+          keys.push(replySnap.key as string);
         });
       });
       currentReplies = keys;
       updateSet();
     });
 
-    // subreplies receipt is 3-level: postId → replyId → subReplyId
+    // subreplies receipt is 3-level: postId -> replyId -> subReplyId -> true
     const subRepliesUnsub = onValue(subRepliesRef, (snap) => {
       const keys: string[] = [];
       snap.forEach((postGroup) => {
         postGroup.forEach((replyGroup) => {
-          replyGroup.forEach((child) => {
-            keys.push(child.key as string);
+          replyGroup.forEach((subReplySnap) => {
+            keys.push(subReplySnap.key as string);
           });
         });
       });

--- a/src/hooks/useDeepLinkHandler.ts
+++ b/src/hooks/useDeepLinkHandler.ts
@@ -2,9 +2,6 @@ import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { getDeepLinkData } from "../lib/firebase";
 
-// TODO: update this to allow linking to subreplies
-// FIX: share links show landing page instead of skipping it
-
 /**
  * Handles incoming deep links via ?s=ID, ?p=PARENT_ID, and ?r=ROOT_ID.
  */

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -5,8 +5,13 @@ import { SortOption } from "../context/FeedSortContext";
 
 // module level cache
 const weightMap = new Map<string, number>();
+const pinnedPostIds = new Set<string>();
 let cachedLimit = 20;
 let cachedPosts: Post[] = [];
+let firebasePostsRef: Post[] = [];
+
+// listeners to force re-render when a post is manually pinned
+const pinListeners = new Set<() => void>();
 
 const getPostWeight = (postId: string) => {
   if (!weightMap.has(postId)) {
@@ -20,7 +25,12 @@ const getPostWeight = (postId: string) => {
  * use this for new posts created by the user to provide immediate feedback.
  */
 export const pinPostToTop = (postId: string) => {
-  weightMap.set(postId, -1);
+  pinnedPostIds.add(postId);
+  pinListeners.forEach((listener) => listener());
+};
+
+export const clearPinnedPosts = () => {
+  pinnedPostIds.clear();
 };
 
 /**
@@ -31,47 +41,61 @@ export const usePosts = (initialLimit: number = 20, sortType: SortOption) => {
   // ensures the Feed renders full-height immediately on mount.
   const [posts, setPosts] = useState<Post[]>(() => cachedPosts);
 
-  // initialize limit from cache
   const [currentLimit, setCurrentLimit] = useState(() =>
     Math.max(initialLimit, cachedLimit),
   );
 
   const [loading, setLoading] = useState(true);
+  const [pinTrigger, setPinTrigger] = useState(0);
 
   // Sync limit cache
   useEffect(() => {
     cachedLimit = currentLimit;
   }, [currentLimit]);
 
+  // Listen for manual pins
+  useEffect(() => {
+    const listener = () => setPinTrigger((t) => t + 1);
+    pinListeners.add(listener);
+    return () => {
+      pinListeners.delete(listener);
+    };
+  }, []);
+
   useEffect(() => {
     // ensure loading state is set when changing sort modes or increasing limits
     setLoading(true);
 
     const unsubscribe = subscribeToFeed(currentLimit, (postsArray) => {
-      // create a shallow copy to avoid mutating the original array from firebase
-      let finalPosts = [...postsArray];
-
-      // apply random sort if requested; newest is already handled by subscribeToFeed
-      if (sortType === "random") {
-        finalPosts.sort((a, b) => getPostWeight(a.id) - getPostWeight(b.id));
-      }
-
-      // Always keep explicitly pinned newly created posts at the top.
-      finalPosts.sort((a, b) => {
-        const aPinned = getPostWeight(a.id) === -1 ? 1 : 0;
-        const bPinned = getPostWeight(b.id) === -1 ? 1 : 0;
-        return bPinned - aPinned;
-      });
-
-      // update state and cache
-      setPosts(finalPosts);
-      cachedPosts = finalPosts;
-
+      firebasePostsRef = postsArray;
+      setPinTrigger((t) => t + 1); // trigger resort
       setLoading(false);
     });
 
     return () => unsubscribe();
-  }, [currentLimit, sortType]);
+  }, [currentLimit]);
+
+  // Compute sorted posts whenever Firebase updates, sortType changes, or a post is pinned
+  useEffect(() => {
+    if (firebasePostsRef.length === 0) return;
+
+    // split into pinned and regular
+    const pinnedPosts = firebasePostsRef.filter((p) => pinnedPostIds.has(p.id));
+    const regularPosts = firebasePostsRef.filter(
+      (p) => !pinnedPostIds.has(p.id),
+    );
+
+    // apply random sort to regular posts if requested
+    if (sortType === "random") {
+      regularPosts.sort((a, b) => getPostWeight(a.id) - getPostWeight(b.id));
+    }
+
+    // pinned posts always stay exactly at the top
+    const finalPosts = [...pinnedPosts, ...regularPosts];
+
+    setPosts(finalPosts);
+    cachedPosts = finalPosts;
+  }, [pinTrigger, sortType]);
 
   const loadMore = () => {
     // Only load more if we aren't currently loading

--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -1,29 +1,14 @@
 import { useCallback } from "react";
 import { Post } from "../types";
+import { buildShareUrl } from "../lib/updateBuilders";
 
 /**
  * handles sharing logic and generates links for Social Previews.
  */
 export const useShare = () => {
   const sharePost = useCallback(async (post: Post) => {
-    const url = new URL(window.location.origin);
-    url.pathname = "/share";
+    const shareUrl = buildShareUrl(post, window.location.origin);
 
-    const { id, parentPostId, parentReplyId } = post;
-
-    // logic: s = target content ID, p = direct parent, r = root thread post
-    url.searchParams.set("s", id);
-
-    if (parentReplyId && parentPostId) {
-      // sub-reply case
-      url.searchParams.set("p", parentReplyId);
-      url.searchParams.set("r", parentPostId);
-    } else if (parentPostId) {
-      // standard reply case
-      url.searchParams.set("p", parentPostId);
-    }
-
-    const shareUrl = url.toString();
     const shareData = {
       title: "The Open Dissent",
       text: `Check out this discussion on TheOpenDissent!`,

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -126,6 +126,13 @@ export const createPost = async ({
     updates[
       `users/${userId}/subreplies/${parentPostId}/${parentReplyId}/${newKey}`
     ] = true;
+    // authorLookup for subreply
+    updates[`authorLookup/${newKey}`] = {
+      uid: userId,
+      type: "subreply",
+      postId: parentPostId,
+      replyId: parentReplyId,
+    };
   } else if (parentPostId) {
     // reply
     updates[`replies/${parentPostId}/${newKey}`] = {
@@ -140,6 +147,12 @@ export const createPost = async ({
       isThreadAuthor,
     };
     updates[`users/${userId}/replies/${parentPostId}/${newKey}`] = true;
+    // authorLookup for reply
+    updates[`authorLookup/${newKey}`] = {
+      uid: userId,
+      type: "reply",
+      postId: parentPostId,
+    };
   } else {
     // top-level post
     updates[`posts/${newKey}`] = {
@@ -151,6 +164,11 @@ export const createPost = async ({
       replyCount: 0,
     };
     updates[`users/${userId}/posts/${newKey}`] = true;
+    // authorLookup for post
+    updates[`authorLookup/${newKey}`] = {
+      uid: userId,
+      type: "post",
+    };
   }
 
   await update(ref(db), updates);
@@ -190,6 +208,9 @@ export const deletePost = async (
   const { id, parentPostId, parentReplyId } = post;
   try {
     const dbUpdates: Record<string, any> = {};
+
+    // authorLookup is flat, so we can always target the id directly for deletion
+    dbUpdates[`authorLookup/${id}`] = null;
 
     if (parentReplyId && parentPostId) {
       // sub-reply: atomic delete of object + receipt

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -6,7 +6,6 @@ import {
   ref,
   update,
   push,
-  serverTimestamp,
   child,
   get,
   onValue,
@@ -83,6 +82,12 @@ const getSortableTimestamp = (timestamp: number | object | undefined) => {
   return 0;
 };
 
+import {
+  buildCreateUpdates,
+  buildDeleteUpdates,
+  buildEditUpdates,
+} from "./updateBuilders.ts";
+
 /**
  * creates a new post, reply, or sub-reply.
  * pass parentReplyId to write to the subreplies/ tree instead of replies/.
@@ -106,64 +111,16 @@ export const createPost = async ({
   const newKey = push(child(ref(db), mainTree)).key;
   if (!newKey) return;
 
-  const updates: Record<string, any> = {};
-
-  if (parentReplyId && parentPostId) {
-    // sub-reply: no replyCount, no interactionScore
-    updates[`subreplies/${parentPostId}/${parentReplyId}/${newKey}`] = {
-      id: newKey,
-      authorDisplay,
-      postContent: content,
-      timestamp: serverTimestamp(),
-      parentPostId,
-      parentReplyId,
-      ...(isThreadAuthor ? { isThreadAuthor } : {}),
-    };
-    updates[
-      `users/${userId}/subreplies/${parentPostId}/${parentReplyId}/${newKey}`
-    ] = true;
-    // authorLookup for subreply
-    updates[`authorLookup/${newKey}`] = {
-      uid: userId,
-      type: "subreply",
-      postId: parentPostId,
-      replyId: parentReplyId,
-    };
-  } else if (parentPostId) {
-    // reply
-    updates[`replies/${parentPostId}/${newKey}`] = {
-      id: newKey,
-      authorDisplay,
-      postContent: content,
-      timestamp: serverTimestamp(),
-      replyCount: 0,
-      parentPostId,
-      interactionScore: score,
-      isThreadAuthor,
-    };
-    updates[`users/${userId}/replies/${parentPostId}/${newKey}`] = true;
-    // authorLookup for reply
-    updates[`authorLookup/${newKey}`] = {
-      uid: userId,
-      type: "reply",
-      postId: parentPostId,
-    };
-  } else {
-    // top-level post
-    updates[`posts/${newKey}`] = {
-      id: newKey,
-      authorDisplay,
-      postContent: content,
-      timestamp: serverTimestamp(),
-      replyCount: 0,
-    };
-    updates[`users/${userId}/posts/${newKey}`] = true;
-    // authorLookup for post
-    updates[`authorLookup/${newKey}`] = {
-      uid: userId,
-      type: "post",
-    };
-  }
+  const updates = buildCreateUpdates({
+    key: newKey,
+    userId,
+    content,
+    authorDisplay,
+    parentPostId,
+    parentReplyId,
+    score,
+    isThreadAuthor,
+  });
 
   await update(ref(db), updates);
   return newKey;
@@ -171,59 +128,25 @@ export const createPost = async ({
 
 /**
  * updates content in the correct tree (posts/, replies/, or subreplies/).
- * accepts the post object directly so callers don’t thread multiple id params.
+ * accepts the post object directly so callers don't thread multiple id params.
  */
 export const updatePost = async (
   post: Pick<Post, "id" | "parentPostId" | "parentReplyId">,
-  updates: Partial<Pick<Post, "postContent" | "editedAt">>,
+  changes: Partial<Pick<Post, "postContent" | "editedAt">>,
 ) => {
-  const { id, parentPostId, parentReplyId } = post;
-  const path =
-    parentReplyId && parentPostId
-      ? `subreplies/${parentPostId}/${parentReplyId}/${id}`
-      : parentPostId
-        ? `replies/${parentPostId}/${id}`
-        : `posts/${id}`;
-
-  return update(ref(db), {
-    [`${path}/postContent`]: updates.postContent,
-    [`${path}/editedAt`]: updates.editedAt,
-  });
+  return update(ref(db), buildEditUpdates(post, changes));
 };
 
 /**
  * removes a post, reply, or sub-reply and cleans up all associated references atomically.
- * accepts the post object directly so callers don’t thread multiple id params.
+ * accepts the post object directly so callers don't thread multiple id params.
  */
 export const deletePost = async (
   post: Pick<Post, "id" | "parentPostId" | "parentReplyId">,
   userId: string,
 ) => {
-  const { id, parentPostId, parentReplyId } = post;
   try {
-    const dbUpdates: Record<string, any> = {};
-
-    // authorLookup is flat, so we target the id directly
-    dbUpdates[`authorLookup/${id}`] = null;
-
-    if (parentReplyId && parentPostId) {
-      // sub-reply: atomic delete of object + receipt
-      dbUpdates[`subreplies/${parentPostId}/${parentReplyId}/${id}`] = null;
-      dbUpdates[
-        `users/${userId}/subreplies/${parentPostId}/${parentReplyId}/${id}`
-      ] = null;
-    } else if (parentPostId) {
-      // reply: atomic delete of object + receipt
-      dbUpdates[`replies/${parentPostId}/${id}`] = null;
-      dbUpdates[`users/${userId}/replies/${parentPostId}/${id}`] = null;
-    } else {
-      // post: delete object + receipt
-      dbUpdates[`posts/${id}`] = null;
-      dbUpdates[`users/${userId}/posts/${id}`] = null;
-      // cloud function handles cascade to replies/ to avoid permission errors
-    }
-
-    await update(ref(db), dbUpdates);
+    await update(ref(db), buildDeleteUpdates(post, userId));
   } catch (error) {
     console.error("error deleting content:", error);
     throw error;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -55,8 +55,6 @@ export interface CreatePostOptions {
   /** stance score — replies only */
   score?: number;
   isThreadAuthor?: boolean;
-  /** include userId in the public object (non-anonymous mode) */
-  includePublicUserId?: boolean;
 }
 
 const app = initializeApp(firebaseConfig);
@@ -97,7 +95,6 @@ export const createPost = async ({
   parentReplyId,
   score,
   isThreadAuthor,
-  includePublicUserId = false,
 }: CreatePostOptions) => {
   const mainTree =
     parentReplyId && parentPostId
@@ -115,7 +112,6 @@ export const createPost = async ({
     // sub-reply: no replyCount, no interactionScore
     updates[`subreplies/${parentPostId}/${parentReplyId}/${newKey}`] = {
       id: newKey,
-      ...(includePublicUserId ? { userId } : {}),
       authorDisplay,
       postContent: content,
       timestamp: serverTimestamp(),
@@ -137,7 +133,6 @@ export const createPost = async ({
     // reply
     updates[`replies/${parentPostId}/${newKey}`] = {
       id: newKey,
-      ...(includePublicUserId ? { userId } : {}),
       authorDisplay,
       postContent: content,
       timestamp: serverTimestamp(),
@@ -157,7 +152,6 @@ export const createPost = async ({
     // top-level post
     updates[`posts/${newKey}`] = {
       id: newKey,
-      ...(includePublicUserId ? { userId } : {}),
       authorDisplay,
       postContent: content,
       timestamp: serverTimestamp(),

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -209,7 +209,7 @@ export const deletePost = async (
   try {
     const dbUpdates: Record<string, any> = {};
 
-    // authorLookup is flat, so we can always target the id directly for deletion
+    // authorLookup is flat, so we target the id directly
     dbUpdates[`authorLookup/${id}`] = null;
 
     if (parentReplyId && parentPostId) {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -430,7 +430,6 @@ export const subscribeToFeed = (
     const postsArray: Post[] = Object.entries(postsObject)
       .map(([postId, postData]: [string, any]) => ({
         id: postId,
-        userId: postData.userId,
         authorDisplay: postData.authorDisplay,
         postContent: postData.postContent || postData.content,
         timestamp: postData.timestamp || 0,

--- a/src/lib/updateBuilders.ts
+++ b/src/lib/updateBuilders.ts
@@ -1,0 +1,185 @@
+import { Post } from "../types/index.ts";
+
+/**
+ * Server timestamp placeholder — works in both the Firebase client SDK
+ * (`update()` accepts raw wire format) and `@firebase/rules-unit-testing`.
+ */
+const SERVER_TIMESTAMP = { ".sv": "timestamp" };
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export interface BuildCreateOptions {
+  key: string;
+  userId: string;
+  content: string;
+  authorDisplay: string;
+  parentPostId?: string;
+  parentReplyId?: string;
+  score?: number;
+  isThreadAuthor?: boolean;
+}
+
+/**
+ * Builds the atomic multi-path update for creating a post, reply, or sub-reply.
+ * Returns a flat `Record<string, any>` ready for `db.ref().update()`.
+ */
+export const buildCreateUpdates = ({
+  key,
+  userId,
+  content,
+  authorDisplay,
+  parentPostId,
+  parentReplyId,
+  score,
+  isThreadAuthor,
+}: BuildCreateOptions): Record<string, any> => {
+  const updates: Record<string, any> = {};
+
+  if (parentReplyId && parentPostId) {
+    // sub-reply
+    updates[`subreplies/${parentPostId}/${parentReplyId}/${key}`] = {
+      id: key,
+      authorDisplay,
+      postContent: content,
+      timestamp: SERVER_TIMESTAMP,
+      parentPostId,
+      parentReplyId,
+      ...(isThreadAuthor ? { isThreadAuthor } : {}),
+    };
+    updates[
+      `users/${userId}/subreplies/${parentPostId}/${parentReplyId}/${key}`
+    ] = true;
+    updates[`authorLookup/${key}`] = {
+      uid: userId,
+      type: "subreply",
+      postId: parentPostId,
+      replyId: parentReplyId,
+    };
+  } else if (parentPostId) {
+    // reply
+    updates[`replies/${parentPostId}/${key}`] = {
+      id: key,
+      authorDisplay,
+      postContent: content,
+      timestamp: SERVER_TIMESTAMP,
+      replyCount: 0,
+      parentPostId,
+      ...(score !== undefined ? { interactionScore: score } : {}),
+      ...(isThreadAuthor !== undefined ? { isThreadAuthor } : {}),
+    };
+    updates[`users/${userId}/replies/${parentPostId}/${key}`] = true;
+    updates[`authorLookup/${key}`] = {
+      uid: userId,
+      type: "reply",
+      postId: parentPostId,
+    };
+  } else {
+    // top-level post
+    updates[`posts/${key}`] = {
+      id: key,
+      authorDisplay,
+      postContent: content,
+      timestamp: SERVER_TIMESTAMP,
+      replyCount: 0,
+    };
+    updates[`users/${userId}/posts/${key}`] = true;
+    updates[`authorLookup/${key}`] = {
+      uid: userId,
+      type: "post",
+    };
+  }
+
+  return updates;
+};
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the atomic multi-path null-update for deleting a post, reply, or sub-reply.
+ */
+export const buildDeleteUpdates = (
+  post: Pick<Post, "id" | "parentPostId" | "parentReplyId">,
+  userId: string,
+): Record<string, any> => {
+  const { id, parentPostId, parentReplyId } = post;
+  const updates: Record<string, any> = {};
+
+  // authorLookup is flat keyed by content id
+  updates[`authorLookup/${id}`] = null;
+
+  if (parentReplyId && parentPostId) {
+    updates[`subreplies/${parentPostId}/${parentReplyId}/${id}`] = null;
+    updates[
+      `users/${userId}/subreplies/${parentPostId}/${parentReplyId}/${id}`
+    ] = null;
+  } else if (parentPostId) {
+    updates[`replies/${parentPostId}/${id}`] = null;
+    updates[`users/${userId}/replies/${parentPostId}/${id}`] = null;
+  } else {
+    updates[`posts/${id}`] = null;
+    updates[`users/${userId}/posts/${id}`] = null;
+    // cloud function handles cascade to replies/subreplies
+  }
+
+  return updates;
+};
+
+// ---------------------------------------------------------------------------
+// Edit
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the multi-path update for editing postContent and/or editedAt.
+ */
+export const buildEditUpdates = (
+  post: Pick<Post, "id" | "parentPostId" | "parentReplyId">,
+  changes: Partial<Pick<Post, "postContent" | "editedAt">>,
+): Record<string, any> => {
+  const { id, parentPostId, parentReplyId } = post;
+  const path =
+    parentReplyId && parentPostId
+      ? `subreplies/${parentPostId}/${parentReplyId}/${id}`
+      : parentPostId
+        ? `replies/${parentPostId}/${id}`
+        : `posts/${id}`;
+
+  return {
+    [`${path}/postContent`]: changes.postContent,
+    [`${path}/editedAt`]: changes.editedAt,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Share URL
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the share URL for a post, reply, or sub-reply.
+ * Pure function — takes origin as a parameter instead of reading window.location.
+ */
+export const buildShareUrl = (
+  post: Pick<Post, "id" | "parentPostId" | "parentReplyId">,
+  origin: string,
+): string => {
+  const url = new URL(origin);
+  url.pathname = "/share";
+
+  const { id, parentPostId, parentReplyId } = post;
+
+  url.searchParams.set("s", id);
+
+  if (parentReplyId && parentPostId) {
+    // sub-reply: p = direct parent (reply), r = root (post)
+    url.searchParams.set("p", parentReplyId);
+    url.searchParams.set("r", parentPostId);
+  } else if (parentPostId) {
+    // reply: p = parent post
+    url.searchParams.set("p", parentPostId);
+  }
+
+  return url.toString();
+};

--- a/src/pages/PostDetails.tsx
+++ b/src/pages/PostDetails.tsx
@@ -176,7 +176,6 @@ export const PostDetails = () => {
                     highlighted={
                       highlightReplyId === reply.id && !highlightSubReplyId
                     }
-                    threadAuthorUserId={livePost?.userId}
                     onReply={() => {
                       setActiveReplyTo(reply);
                       setIsComposeOpen(true);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,5 @@
 export interface Post {
   id: string;
-  userId?: string; // Optional for newer anonymous posts
   authorDisplay?: string; // e.g., "Anonymous User", "User_...", or "Display Name"
   postContent: string;
   timestamp: number | object;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,95 @@
+# Database Security Rules Tests
+
+- READS
+  - DENIES
+    - public user
+      - read to users/
+      - read to users/{uid}
+      - read to users/{uid}/posts
+      - read to users/{uid}/replies
+      - read to users/{uid}/notifications
+      - read to users/{uid}/subreplies
+      - read to users/{uid}/displayName
+      - read to users/{uid}/email
+      - read to users/{uid}/postInteractions
+    - some user B
+      - read to users/{uidA}
+      - read to users/{uidA}/posts
+      - read to users/{uidA}/replies
+      - read to users/{uidA}/notifications
+      - read to users/{uidA}/subreplies
+      - read to users/{uidA}/displayName
+      - read to users/{uidA}/email
+      - read to users/{uidA}/postInteractions
+  - ALLOWS
+    - public user read to posts/, replies/, subreplies/
+    - auth user read to posts/, replies/, subreplies/
+    - user A read from users/uidA/notifications/test
+
+- WRITES
+  - protected fields
+    - DENIES
+      - public/other user to posts/postId/replyCount
+      - public/other user to replies/replyId/replyCount
+      - public user to replies/reply or posts/post or subreplies/subreply
+    - ALLOWS
+      - user A write to users/uidA/notifications/test
+  - post creation
+    - DENIES
+      - without profile receipt
+      - without ownership receipt
+      - without main object (with profile XOR ownership) (2)
+      - not logged in
+      - user B write to users/uidA/posts/evil
+      - including userId
+      - timestamp missing
+      - over 600 chars
+    - ALLOWS
+      - with profile receipt + ownership receipt + required fields
+  - reply creation
+    - DENIES
+      - without profile receipt
+      - without ownership receipt
+      - without main object (with profile XOR ownership) (2)
+      - not logged in
+      - user B write to users/uidA/replies/evil
+      - including userId
+      - timestamp missing
+      - over 600 chars
+      - out of range interactionScore
+      - wrong parentPostId
+      - missing parentPostId
+      - missing interactionScore
+    - ALLOWS
+      - with profile receipt + ownership receipt + required fields (parentPostId, interactionScore)
+  - subreply creation
+    - DENIES
+      - without profile receipt
+      - without ownership receipt
+      - without main object (with profile XOR ownership) (2)
+      - not logged in
+      - user B write to users/uidA/subreplies/evil
+      - including userId
+      - timestamp missing
+      - over 600 chars
+      - wrong parentPostId
+      - wrong rootPostId
+      - missing parentPostId
+      - missing rootPostId
+    - ALLOWS
+      - with profile receipt + ownership receipt + required fields (parentPostId, rootPostId)
+
+- DELETES
+  - ALLOWS
+    - deleting post (that doesnt have userId field) with both receipts sent
+  - DENIES
+    - deleting post (that doesnt have userId field) with only profile receipt
+    - deleting post (that doesnt have userId field) with only ownership receipt
+      - without main object (with profile XOR ownership) (2)
+    - non-owner delete (post/reply/subreply) (3)
+
+- EDITS
+  - ALLOWS
+    - owner edit postContent
+  - DENIES
+    - non-owner edit postContent

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -177,7 +177,7 @@ describe("Realtime Database rules", () => {
     });
   });
 
-  describe("Writes", () => {
+  describe("Writes (create/delete)", () => {
     describe("To Protected Fields", () => {
       describe("Denied Writes", () => {
         // 1. Check that replyCount is protected from everyone except the system (Cloud Functions)
@@ -338,271 +338,426 @@ describe("Realtime Database rules", () => {
       });
     });
 
-    it("denies deleting only the sub-reply object (without receipt)", async () => {
-      const dbA = authedDb(uidA);
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "to delete",
-            timestamp: Date.now(),
+    describe("Post/Reply/SubReply Creation and Deletion", () => {
+      const newId = "new_id_123";
+
+      // shared scenarios
+      const scenarios = [
+        {
+          label: "Post",
+          path: `posts/${newId}`,
+          profile: `users/${uidCurrent}/posts/${newId}`,
+          lookup: `authorLookup/${newId}`,
+          validData: {
+            id: newId,
+            postContent: "test content",
+            timestamp: { ".sv": "timestamp" },
+            replyCount: 0,
+          },
+        },
+        {
+          label: "Reply",
+          path: `replies/${postId}/${newId}`,
+          profile: `users/${uidCurrent}/replies/${postId}/${newId}`,
+          lookup: `authorLookup/${newId}`,
+          validData: {
+            id: newId,
+            postContent: "test reply",
+            timestamp: { ".sv": "timestamp" },
+            parentPostId: postId,
+            interactionScore: 0,
+            replyCount: 0,
+          },
+        },
+        {
+          label: "Sub-Reply",
+          path: `subreplies/${postId}/${replyId}/${newId}`,
+          profile: `users/${uidCurrent}/subreplies/${postId}/${replyId}/${newId}`,
+          lookup: `authorLookup/${newId}`,
+          validData: {
+            id: newId,
+            postContent: "test sub",
+            timestamp: { ".sv": "timestamp" },
             parentPostId: postId,
             parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
+            authorDisplay: "Anon",
           },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
+        },
+      ];
+
+      describe("Shared Atomic Denials", () => {
+        it.each(scenarios)(
+          "denies partial $label creation writes",
+          async ({ path, profile, lookup, validData }) => {
+            const db = userDb(uidCurrent);
+
+            // - only main object
+            await assertFails(dbSet(db, path, validData));
+            // - only profile receipt
+            await assertFails(dbSet(db, profile, true));
+            // - only ownership receipt
+            await assertFails(dbSet(db, lookup, uidCurrent));
+            // - only profile + ownership receipt
+            await assertFails(
+              dbUpdate(db, "/", { [profile]: true, [lookup]: uidCurrent }),
+            );
+            // - only main + profile receipt
+            await assertFails(
+              dbUpdate(db, "/", { [path]: validData, [profile]: true }),
+            );
+            // - only main + ownership receipt
+            await assertFails(
+              dbUpdate(db, "/", { [path]: validData, [lookup]: uidCurrent }),
+            );
+          },
+        );
+
+        it.each(scenarios)(
+          "denies unauthenticated creation of $label",
+          async ({ path, profile, lookup, validData }) => {
+            await assertFails(
+              dbUpdate(guestDb(), "/", {
+                [path]: validData,
+                [profile]: true,
+                [lookup]: uidCurrent,
+              }),
+            );
+          },
+        );
+
+        it.each(scenarios)(
+          "denies UID mismatch (User B on User A paths)",
+          async ({ path, profile, lookup, validData }) => {
+            // User B tries to claim they are the owner in the lookup or profile while authed as B
+            await assertFails(
+              dbUpdate(userDb(uidOther), "/", {
+                [path]: validData,
+                [profile]: true,
+                [`authorLookup/${newId}`]: uidCurrent,
+              }),
+            );
+          },
+        );
+      });
+
+      describe("Post/Reply/SubReply Creation Validation", () => {
+        it.each(scenarios)(
+          "denies $label creation with invalid fields",
+          async ({ path, profile, lookup, validData }) => {
+            const db = userDb(uidCurrent);
+
+            // - wrongly includes userId (Shadow Tree prohibits this)
+            await assertFails(
+              dbUpdate(db, "/", {
+                [path]: { ...validData, userId: uidCurrent },
+                [profile]: true,
+                [lookup]: uidCurrent,
+              }),
+            );
+
+            // - timestamp missing
+            const { timestamp, ...noTime } = validData as any;
+            await assertFails(
+              dbUpdate(db, "/", {
+                [path]: noTime,
+                [profile]: true,
+                [lookup]: uidCurrent,
+              }),
+            );
+
+            // - over 600 chars
+            await assertFails(
+              dbUpdate(db, "/", {
+                [path]: { ...validData, postContent: "A".repeat(601) },
+                [profile]: true,
+                [lookup]: uidCurrent,
+              }),
+            );
+          },
+        );
+      });
+
+      describe("Post Creation", () => {
+        it("allows: all required fields + both receipts", async () => {
+          const s = scenarios[0];
+          await assertSucceeds(
+            userDb(uidCurrent)
+              .ref("/")
+              .update({
+                [s.path]: s.validData,
+                [s.profile]: true,
+                [s.lookup]: uidCurrent,
+              }),
+          );
         });
       });
 
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-        }),
-      );
-    });
-
-    it("denies deleting only the receipt (without sub-reply object)", async () => {
-      const dbA = authedDb(uidA);
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "to delete",
-            timestamp: Date.now(),
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
+      describe("Reply Creation", () => {
+        const s = scenarios[1];
+        it.each([
+          {
+            desc: "out of range interactionScore",
+            data: { ...s.validData, interactionScore: 5 },
           },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
+          {
+            desc: "wrong parentPostId",
+            data: { ...s.validData, parentPostId: "wrong_id" },
+          },
+          {
+            desc: "missing parentPostId",
+            data: {
+              id: newId,
+              postContent: "...",
+              timestamp: { ".sv": "timestamp" },
+              interactionScore: 0,
+              replyCount: 0,
+            },
+          },
+          {
+            desc: "missing interactionScore",
+            data: {
+              id: newId,
+              postContent: "...",
+              timestamp: { ".sv": "timestamp" },
+              parentPostId: postId,
+              replyCount: 0,
+            },
+          },
+        ])("denies reply creation: $desc", async ({ data }) => {
+          await assertFails(
+            dbUpdate(userDb(uidCurrent), "/", {
+              [s.path]: data,
+              [s.profile]: true,
+              [s.lookup]: uidCurrent,
+            }),
+          );
+        });
+
+        it("allows: all required fields + receipts", async () => {
+          await assertSucceeds(
+            dbUpdate(userDb(uidCurrent), "/", {
+              [s.path]: s.validData,
+              [s.profile]: true,
+              [s.lookup]: uidCurrent,
+            }),
+          );
         });
       });
 
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-        }),
-      );
+      describe("Sub-Reply Creation", () => {
+        const s = scenarios[2];
+        it.each([
+          {
+            desc: "wrong parentReplyId",
+            data: { ...s.validData, parentReplyId: "wrong_reply" },
+          },
+          {
+            desc: "wrong parentPostId (root)",
+            data: { ...s.validData, parentPostId: "wrong_post" },
+          },
+          {
+            desc: "missing parentReplyId",
+            data: {
+              id: newId,
+              postContent: "...",
+              timestamp: { ".sv": "timestamp" },
+              parentPostId: postId,
+              authorDisplay: "Anon",
+            },
+          },
+          {
+            desc: "missing parentPostId",
+            data: {
+              id: newId,
+              postContent: "...",
+              timestamp: { ".sv": "timestamp" },
+              parentReplyId: replyId,
+              authorDisplay: "Anon",
+            },
+          },
+        ])("denies sub-reply creation: $desc", async ({ data }) => {
+          await assertFails(
+            dbUpdate(userDb(uidCurrent), "/", {
+              [s.path]: data,
+              [s.profile]: true,
+              [s.lookup]: uidCurrent,
+            }),
+          );
+        });
+
+        it("allows: all required fields + receipts", async () => {
+          await assertSucceeds(
+            dbUpdate(userDb(uidCurrent), "/", {
+              [s.path]: s.validData,
+              [s.profile]: true,
+              [s.lookup]: uidCurrent,
+            }),
+          );
+        });
+      });
+
+      describe("Post/Reply/SubReply Deletion", () => {
+        it.each(scenarios)(
+          "allows $label deletion: main object + both receipts sent",
+          async ({ path, profile, lookup, validData }) => {
+            const db = userDb(uidCurrent);
+            // Seed first
+            await testEnv.withSecurityRulesDisabled((c) =>
+              dbUpdate(dbFromContext(c), "/", {
+                [path]: validData,
+                [profile]: true,
+                [lookup]: uidCurrent,
+              }),
+            );
+
+            // Atomic delete
+            await assertSucceeds(
+              dbUpdate(db, "/", {
+                [path]: null,
+                [profile]: null,
+                [lookup]: null,
+              }),
+            );
+          },
+        );
+
+        it.each(scenarios)(
+          "denies deletion of $label by wrong user or guest",
+          async ({ path, profile, lookup, validData }) => {
+            await testEnv.withSecurityRulesDisabled((c) =>
+              dbUpdate(dbFromContext(c), "/", {
+                [path]: validData,
+                [profile]: true,
+                [lookup]: uidCurrent,
+              }),
+            );
+
+            await assertFails(
+              dbUpdate(userDb(uidOther), "/", {
+                [path]: null,
+                [profile]: null,
+                [lookup]: null,
+              }),
+            );
+            await assertFails(
+              dbUpdate(guestDb(), "/", {
+                [path]: null,
+                [profile]: null,
+                [lookup]: null,
+              }),
+            );
+          },
+        );
+      });
     });
   });
 
-  describe("Non-Anonymous Sub-Reply Creation + Deletion", () => {
-    const subReplyId = "subreply_named_1";
+  describe("Edits", () => {
+    const scenarios = [
+      {
+        label: "Post",
+        path: `posts/${postId}`,
+        lookup: `authorLookup/${postId}`,
+        profile: `users/${uidCurrent}/posts/${postId}`,
+      },
+      {
+        label: "Reply",
+        path: `replies/${postId}/${replyId}`,
+        lookup: `authorLookup/${replyId}`,
+        profile: `users/${uidCurrent}/replies/${postId}/${replyId}`,
+      },
+      {
+        label: "Sub-Reply",
+        path: `subreplies/${postId}/${replyId}/sub_1`,
+        lookup: `authorLookup/sub_1`,
+        profile: `users/${uidCurrent}/subreplies/${postId}/${replyId}/sub_1`,
+      },
+    ];
 
-    it("allows creating a non-anonymous sub-reply with userId", async () => {
-      const dbB = authedDb(uidB);
-      await assertSucceeds(
-        dbUpdate(dbB, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            userId: uidB,
-            postContent: "named sub-reply",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "User B",
-          },
-          [`users/${uidB}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("denies creating a sub-reply with a mismatched userId", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            userId: uidB, // wrong — auth is user_a
-            postContent: "spoofed identity",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "User B",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("allows deleting a non-anonymous sub-reply (with receipt)", async () => {
-      const dbB = authedDb(uidB);
+    beforeEach(async () => {
+      // seed the database with the objects to be edited
       await testEnv.withSecurityRulesDisabled(async (context) => {
         const db = dbFromContext(context);
+        const now = Date.now();
         await dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            userId: uidB,
-            postContent: "named sub to delete",
-            timestamp: Date.now(),
+          [scenarios[0].path]: {
+            id: postId,
+            postContent: "orig",
+            timestamp: now,
+            replyCount: 0,
+          },
+          [scenarios[0].lookup]: uidCurrent,
+          [scenarios[0].profile]: true,
+
+          [scenarios[1].path]: {
+            id: replyId,
+            postContent: "orig",
+            timestamp: now,
+            parentPostId: postId,
+            interactionScore: 0,
+            replyCount: 0,
+          },
+          [scenarios[1].lookup]: uidCurrent,
+          [scenarios[1].profile]: true,
+
+          [scenarios[2].path]: {
+            id: "sub_1",
+            postContent: "orig",
+            timestamp: now,
             parentPostId: postId,
             parentReplyId: replyId,
-            authorDisplay: "User B",
+            authorDisplay: "Anon",
           },
-          [`users/${uidB}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
+          [scenarios[2].lookup]: uidCurrent,
+          [scenarios[2].profile]: true,
         });
       });
+    });
 
-      await assertSucceeds(
-        dbUpdate(dbB, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-          [`users/${uidB}/subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-        }),
+    describe("Allowed Edits", () => {
+      it.each(scenarios)(
+        "allows owner to edit postContent and editedAt for $label",
+        async ({ path }) => {
+          const db = userDb(uidCurrent);
+          await assertSucceeds(
+            dbUpdate(db, path, {
+              postContent: "updated content",
+              editedAt: Date.now(),
+            }),
+          );
+        },
       );
     });
 
-    it("denies a non-owner from deleting another user's sub-reply", async () => {
-      const dbA = authedDb(uidA);
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            userId: uidB,
-            postContent: "belongs to B",
-            timestamp: Date.now(),
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "User B",
-          },
-          [`users/${uidB}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        });
-      });
+    describe("Denied Edits", () => {
+      it.each(scenarios)(
+        "denies owner from editing protected fields in $label",
+        async ({ path }) => {
+          const db = userDb(uidCurrent);
 
-      // User A tries to delete user B's sub-reply using their own receipt slot
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-        }),
+          // - owner edits id
+          await assertFails(dbUpdate(db, path, { id: "new_id" }));
+          // - owner edits timestamp
+          await assertFails(
+            dbUpdate(db, path, { timestamp: Date.now() + 1000 }),
+          );
+          // - owner edits replyCount (if applicable)
+          if (!path.includes("subreplies")) {
+            await assertFails(dbUpdate(db, path, { replyCount: 99 }));
+          }
+        },
       );
-    });
-  });
 
-  describe("Sub-Reply Validation", () => {
-    const subReplyId = "subreply_validate_1";
+      it.each(scenarios)(
+        "denies guest or non-owner from any edit to $label",
+        async ({ path }) => {
+          const dbOther = userDb(uidOther);
+          const dbGuest = guestDb();
+          const edit = { postContent: "hacked" };
 
-    it("denies sub-reply with missing required fields", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "missing timestamp & parentReplyId",
-            parentPostId: postId,
-            authorDisplay: "Anonymous User",
-            // missing: timestamp, parentReplyId
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("denies sub-reply with wrong parentReplyId", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "wrong parentReplyId",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: "wrong_reply_id",
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("denies sub-reply with wrong parentPostId", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "wrong parentPostId",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: "wrong_post_id",
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("denies sub-reply with wrong id field", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: "some_other_id", // does not match $subreply_id
-            postContent: "bad id",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("denies sub-reply with postContent exceeding 600 chars", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "x".repeat(601),
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("denies unauthenticated sub-reply creation", async () => {
-      const db = unAuthedDb();
-      await assertFails(
-        dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "anon write attempt",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-        }),
-      );
-    });
-  });
-
-  describe("Sub-Reply Lazy Cleanup (orphan receipt)", () => {
-    it("allows lazy cleanup of a dangling subreply receipt when public object is gone", async () => {
-      const orphanSubReplyId = "orphan_subreply_999";
-
-      // seed only the receipt, no public object (mimics cloud-fn cascade delete)
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${orphanSubReplyId}`]: true,
-          // note: subreplies/ object is intentionally absent
-        });
-      });
-
-      // client self-heals the dangling receipt
-      await assertSucceeds(
-        dbRemove(
-          authedDb(uidA),
-          `users/${uidA}/subreplies/${postId}/${replyId}/${orphanSubReplyId}`,
-        ),
+          await assertFails(dbUpdate(dbOther, path, edit));
+          await assertFails(dbUpdate(dbGuest, path, edit));
+        },
       );
     });
   });

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -66,9 +66,9 @@ describe("Realtime Database rules", () => {
           postContent: "seed post",
           timestamp: Date.now(),
           replyCount: 0,
-          // userId: uidCurrent, // this is never needed anymore
         },
-        [`authorLookup/${postId}`]: uidCurrent, // this is now required! authorLookup is only accessible to admin, though
+        // authorLookup must be an object now to map the relational tree
+        [`authorLookup/${postId}`]: { uid: uidCurrent, type: "post" },
         [`users/${uidCurrent}/posts/${postId}`]: true,
       });
     });
@@ -81,7 +81,7 @@ describe("Realtime Database rules", () => {
   });
 
   describe("Reads", () => {
-    describe("Denied Reads", () => {
+    describe("Denied", () => {
       const sensitivePaths = [
         "users",
         `users/${uidCurrent}`,
@@ -94,7 +94,7 @@ describe("Realtime Database rules", () => {
         `users/${uidCurrent}/postInteractions`,
       ];
 
-      describe("by Guest User", () => {
+      describe("by Guest", () => {
         it.each(sensitivePaths)("access to %s", async (path) => {
           await assertFails(dbGet(guestDb(), path));
         });
@@ -114,7 +114,7 @@ describe("Realtime Database rules", () => {
       });
     });
 
-    describe("Allowed Reads", () => {
+    describe("Allowed", () => {
       const subReplyId = "sub_1";
 
       beforeAll(async () => {
@@ -225,7 +225,7 @@ describe("Realtime Database rules", () => {
         it("denies users from changing internal 'id' fields", async () => {
           const subReplyPath = `subreplies/${postId}/${replyId}/sub_target`;
 
-          // seed the sub-reply
+          // seed the sub-reply with the new object payload
           await testEnv.withSecurityRulesDisabled(async (context) => {
             const db = dbFromContext(context);
             await dbUpdate(db, "/", {
@@ -234,7 +234,12 @@ describe("Realtime Database rules", () => {
                 postContent: "original",
                 authorDisplay: "Anon",
               },
-              [`authorLookup/sub_target`]: uidCurrent,
+              [`authorLookup/sub_target`]: {
+                uid: uidCurrent,
+                type: "subreply",
+                postId: postId,
+                replyId: replyId,
+              },
               [`users/${uidCurrent}/${subReplyPath}`]: true,
             });
           });
@@ -276,16 +281,17 @@ describe("Realtime Database rules", () => {
       });
     });
 
-    describe("Post/Reply/SubReply Creation and Deletion", () => {
+    describe("To Object", () => {
       const newId = "new_id_123";
 
-      // shared scenarios
+      // shared scenarios include the new lookupData required for authorLookup
       const scenarios = [
         {
           label: "Post",
           path: `posts/${newId}`,
           profile: `users/${uidCurrent}/posts/${newId}`,
           lookup: `authorLookup/${newId}`,
+          lookupData: { uid: uidCurrent, type: "post" },
           validData: {
             id: newId,
             postContent: "test content",
@@ -298,6 +304,7 @@ describe("Realtime Database rules", () => {
           path: `replies/${postId}/${newId}`,
           profile: `users/${uidCurrent}/replies/${postId}/${newId}`,
           lookup: `authorLookup/${newId}`,
+          lookupData: { uid: uidCurrent, type: "reply", postId },
           validData: {
             id: newId,
             postContent: "test reply",
@@ -312,6 +319,7 @@ describe("Realtime Database rules", () => {
           path: `subreplies/${postId}/${replyId}/${newId}`,
           profile: `users/${uidCurrent}/subreplies/${postId}/${replyId}/${newId}`,
           lookup: `authorLookup/${newId}`,
+          lookupData: { uid: uidCurrent, type: "subreply", postId, replyId },
           validData: {
             id: newId,
             postContent: "test sub",
@@ -326,38 +334,38 @@ describe("Realtime Database rules", () => {
       describe("Shared Atomic Denials", () => {
         it.each(scenarios)(
           "denies partial $label creation writes",
-          async ({ path, profile, lookup, validData }) => {
+          async ({ path, profile, lookup, lookupData, validData }) => {
             const db = userDb(uidCurrent);
 
-            // - only main object
+            // only main object
             await assertFails(dbSet(db, path, validData));
-            // - only profile receipt
+            // only profile receipt
             await assertFails(dbSet(db, profile, true));
-            // - only ownership receipt
-            await assertFails(dbSet(db, lookup, uidCurrent));
-            // - only profile + ownership receipt
+            // only ownership receipt
+            await assertFails(dbSet(db, lookup, lookupData));
+            // only profile + ownership receipt
             await assertFails(
-              dbUpdate(db, "/", { [profile]: true, [lookup]: uidCurrent }),
+              dbUpdate(db, "/", { [profile]: true, [lookup]: lookupData }),
             );
-            // - only main + profile receipt
+            // only main + profile receipt
             await assertFails(
               dbUpdate(db, "/", { [path]: validData, [profile]: true }),
             );
-            // - only main + ownership receipt
+            // only main + ownership receipt
             await assertFails(
-              dbUpdate(db, "/", { [path]: validData, [lookup]: uidCurrent }),
+              dbUpdate(db, "/", { [path]: validData, [lookup]: lookupData }),
             );
           },
         );
 
         it.each(scenarios)(
           "denies unauthenticated creation of $label",
-          async ({ path, profile, lookup, validData }) => {
+          async ({ path, profile, lookup, lookupData, validData }) => {
             await assertFails(
               dbUpdate(guestDb(), "/", {
                 [path]: validData,
                 [profile]: true,
-                [lookup]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
           },
@@ -365,50 +373,50 @@ describe("Realtime Database rules", () => {
 
         it.each(scenarios)(
           "denies UID mismatch (User B on User A paths)",
-          async ({ path, profile, lookup, validData }) => {
-            // User B tries to claim they are the owner in the lookup or profile while authed as B
+          async ({ path, profile, lookup, lookupData, validData }) => {
+            // user B tries to claim they are the owner in the lookup or profile while authed as B
             await assertFails(
               dbUpdate(userDb(uidOther), "/", {
                 [path]: validData,
                 [profile]: true,
-                [`authorLookup/${newId}`]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
           },
         );
       });
 
-      describe("Post/Reply/SubReply Creation Validation", () => {
+      describe("All Creation Validation", () => {
         it.each(scenarios)(
           "denies $label creation with invalid fields",
-          async ({ path, profile, lookup, validData }) => {
+          async ({ path, profile, lookup, lookupData, validData }) => {
             const db = userDb(uidCurrent);
 
-            // - wrongly includes userId (Shadow Tree prohibits this)
+            // wrongly includes userId (shadow tree prohibits this)
             await assertFails(
               dbUpdate(db, "/", {
                 [path]: { ...validData, userId: uidCurrent },
                 [profile]: true,
-                [lookup]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
 
-            // - timestamp missing
+            // timestamp missing
             const { timestamp, ...noTime } = validData as any;
             await assertFails(
               dbUpdate(db, "/", {
                 [path]: noTime,
                 [profile]: true,
-                [lookup]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
 
-            // - over 600 chars
+            // over 600 chars
             await assertFails(
               dbUpdate(db, "/", {
                 [path]: { ...validData, postContent: "A".repeat(601) },
                 [profile]: true,
-                [lookup]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
           },
@@ -416,16 +424,26 @@ describe("Realtime Database rules", () => {
       });
 
       describe("Post Creation", () => {
-        it("allows: all required fields + both receipts", async () => {
+        it("allows: all required fields + both receipts (with cleanup)", async () => {
           const s = scenarios[0];
+          const db = userDb(uidCurrent);
+
+          // perform the atomic creation
           await assertSucceeds(
-            userDb(uidCurrent)
-              .ref("/")
-              .update({
-                [s.path]: s.validData,
-                [s.profile]: true,
-                [s.lookup]: uidCurrent,
-              }),
+            db.ref("/").update({
+              [s.path]: s.validData,
+              [s.profile]: true,
+              [s.lookup]: s.lookupData,
+            }),
+          );
+
+          // immediately perform an atomic deletion to clean up the state
+          await assertSucceeds(
+            db.ref("/").update({
+              [s.path]: null,
+              [s.profile]: null,
+              [s.lookup]: null,
+            }),
           );
         });
       });
@@ -466,17 +484,34 @@ describe("Realtime Database rules", () => {
             dbUpdate(userDb(uidCurrent), "/", {
               [s.path]: data,
               [s.profile]: true,
-              [s.lookup]: uidCurrent,
+              [s.lookup]: s.lookupData,
             }),
           );
         });
 
-        it("allows: all required fields + receipts", async () => {
+        it("allows: all required fields + receipts (with cleanup)", async () => {
+          const db = userDb(uidCurrent);
+          const payload = {
+            [s.path]: s.validData,
+            [s.profile]: true,
+            [s.lookup]: s.lookupData,
+          };
+
+          // print the payload to the console
+          console.log(
+            `Payload for ${s.label}:`,
+            JSON.stringify(payload, null, 2),
+          );
+
+          // verify atomic creation
+          await assertSucceeds(dbUpdate(db, "/", payload));
+
+          // verify atomic deletion cleanup
           await assertSucceeds(
-            dbUpdate(userDb(uidCurrent), "/", {
-              [s.path]: s.validData,
-              [s.profile]: true,
-              [s.lookup]: uidCurrent,
+            dbUpdate(db, "/", {
+              [s.path]: null,
+              [s.profile]: null,
+              [s.lookup]: null,
             }),
           );
         });
@@ -518,37 +553,54 @@ describe("Realtime Database rules", () => {
             dbUpdate(userDb(uidCurrent), "/", {
               [s.path]: data,
               [s.profile]: true,
-              [s.lookup]: uidCurrent,
+              [s.lookup]: s.lookupData,
             }),
           );
         });
 
-        it("allows: all required fields + receipts", async () => {
+        it("allows: all required fields + receipts (with cleanup)", async () => {
+          const db = userDb(uidCurrent);
+          const payload = {
+            [s.path]: s.validData,
+            [s.profile]: true,
+            [s.lookup]: s.lookupData,
+          };
+
+          // print the payload to the console
+          console.log(
+            `Payload for ${s.label}:`,
+            JSON.stringify(payload, null, 2),
+          );
+
+          // verify atomic creation
+          await assertSucceeds(dbUpdate(db, "/", payload));
+
+          // verify atomic deletion cleanup
           await assertSucceeds(
-            dbUpdate(userDb(uidCurrent), "/", {
-              [s.path]: s.validData,
-              [s.profile]: true,
-              [s.lookup]: uidCurrent,
+            dbUpdate(db, "/", {
+              [s.path]: null,
+              [s.profile]: null,
+              [s.lookup]: null,
             }),
           );
         });
       });
 
-      describe("Post/Reply/SubReply Deletion", () => {
+      describe("All Deletion", () => {
         it.each(scenarios)(
           "allows $label deletion: main object + both receipts sent",
-          async ({ path, profile, lookup, validData }) => {
+          async ({ path, profile, lookup, lookupData, validData }) => {
             const db = userDb(uidCurrent);
-            // Seed first
+            // seed first
             await testEnv.withSecurityRulesDisabled((c) =>
               dbUpdate(dbFromContext(c), "/", {
                 [path]: validData,
                 [profile]: true,
-                [lookup]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
 
-            // Atomic delete
+            // atomic delete
             await assertSucceeds(
               dbUpdate(db, "/", {
                 [path]: null,
@@ -561,12 +613,12 @@ describe("Realtime Database rules", () => {
 
         it.each(scenarios)(
           "denies deletion of $label by wrong user or guest",
-          async ({ path, profile, lookup, validData }) => {
+          async ({ path, profile, lookup, lookupData, validData }) => {
             await testEnv.withSecurityRulesDisabled((c) =>
               dbUpdate(dbFromContext(c), "/", {
                 [path]: validData,
                 [profile]: true,
-                [lookup]: uidCurrent,
+                [lookup]: lookupData,
               }),
             );
 
@@ -624,7 +676,7 @@ describe("Realtime Database rules", () => {
             timestamp: now,
             replyCount: 0,
           },
-          [scenarios[0].lookup]: uidCurrent,
+          [scenarios[0].lookup]: { uid: uidCurrent, type: "post" },
           [scenarios[0].profile]: true,
 
           [scenarios[1].path]: {
@@ -635,7 +687,7 @@ describe("Realtime Database rules", () => {
             interactionScore: 0,
             replyCount: 0,
           },
-          [scenarios[1].lookup]: uidCurrent,
+          [scenarios[1].lookup]: { uid: uidCurrent, type: "reply", postId },
           [scenarios[1].profile]: true,
 
           [scenarios[2].path]: {
@@ -646,13 +698,18 @@ describe("Realtime Database rules", () => {
             parentReplyId: replyId,
             authorDisplay: "Anon",
           },
-          [scenarios[2].lookup]: uidCurrent,
+          [scenarios[2].lookup]: {
+            uid: uidCurrent,
+            type: "subreply",
+            postId: postId,
+            replyId: replyId,
+          },
           [scenarios[2].profile]: true,
         });
       });
     });
 
-    describe("Allowed Edits", () => {
+    describe("Allowed", () => {
       it.each(scenarios)(
         "allows owner to edit postContent and editedAt for $label",
         async ({ path }) => {
@@ -667,19 +724,19 @@ describe("Realtime Database rules", () => {
       );
     });
 
-    describe("Denied Edits", () => {
+    describe("Denied", () => {
       it.each(scenarios)(
         "denies owner from editing protected fields in $label",
         async ({ path }) => {
           const db = userDb(uidCurrent);
 
-          // - owner edits id
+          // owner edits id
           await assertFails(dbUpdate(db, path, { id: "new_id" }));
-          // - owner edits timestamp
+          // owner edits timestamp
           await assertFails(
             dbUpdate(db, path, { timestamp: Date.now() + 1000 }),
           );
-          // - owner edits replyCount (if applicable)
+          // owner edits replyCount (if applicable)
           if (!path.includes("subreplies")) {
             await assertFails(dbUpdate(db, path, { replyCount: 99 }));
           }

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -1181,7 +1181,6 @@ describe("Realtime Database rules", () => {
     });
   });
 
-
   describe("Sub-Reply Lazy Cleanup (orphan receipt)", () => {
     it("allows lazy cleanup of a dangling subreply receipt when public object is gone", async () => {
       const orphanSubReplyId = "orphan_subreply_999";

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -66,8 +66,9 @@ describe("Realtime Database rules", () => {
           postContent: "seed post",
           timestamp: Date.now(),
           replyCount: 0,
-          userId: uidA,
+          // userId: uidA, // this is never needed anymore
         },
+        [`authorLookup/${postId}`]: uidA, // this is now required! authorLookup is only accessible to admin, though
         [`users/${uidA}/posts/${postId}`]: true,
       });
     });

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -499,12 +499,6 @@ describe("Realtime Database rules", () => {
             [s.lookup]: s.lookupData,
           };
 
-          // print the payload to the console
-          console.log(
-            `Payload for ${s.label}:`,
-            JSON.stringify(payload, null, 2),
-          );
-
           // verify atomic creation
           await assertSucceeds(dbUpdate(db, "/", payload));
 
@@ -567,12 +561,6 @@ describe("Realtime Database rules", () => {
             [s.profile]: true,
             [s.lookup]: s.lookupData,
           };
-
-          // print the payload to the console
-          console.log(
-            `Payload for ${s.label}:`,
-            JSON.stringify(payload, null, 2),
-          );
 
           // verify atomic creation
           await assertSucceeds(dbUpdate(db, "/", payload));

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -64,6 +64,7 @@ describe("Realtime Database rules", () => {
       await dbUpdate(db, "/", {
         [`posts/${postId}`]: {
           postContent: "seed post",
+          authorDisplay: "Anon",
           timestamp: Date.now(),
           replyCount: 0,
         },
@@ -307,6 +308,7 @@ describe("Realtime Database rules", () => {
           lookupData: { uid: uidCurrent, type: "reply", postId },
           validData: {
             id: newId,
+            authorDisplay: "Anon",
             postContent: "test reply",
             timestamp: { ".sv": "timestamp" },
             parentPostId: postId,

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -12,8 +12,8 @@ import {
 const PROJECT_ID = "the-open-dissent-prod";
 const DB_NAME = "the-open-dissent-prod-default-rtdb";
 
-const uidA = "user_a";
-const uidB = "user_b";
+const uidCurrent = "user_current"; // currently logged in user, used as target
+const uidOther = "user_other"; // some other logged in userA
 const postId = "post_1";
 const replyId = "reply_1";
 
@@ -22,21 +22,21 @@ let testEnv: RulesTestEnvironment;
 const dbFromContext = (context: RulesTestContext) =>
   context.database(`http://127.0.0.1:9000?ns=${DB_NAME}`);
 
-const authedDb = (uid: string) =>
+const userDb = (uid: string) =>
   dbFromContext(testEnv.authenticatedContext(uid));
 
-const unAuthedDb = () => dbFromContext(testEnv.unauthenticatedContext());
+const guestDb = () => dbFromContext(testEnv.unauthenticatedContext());
 
-const dbGet = (db: ReturnType<typeof authedDb>, path: string) =>
+const dbGet = (db: ReturnType<typeof userDb>, path: string) =>
   db.ref(path).once("value");
-const dbSet = (db: ReturnType<typeof authedDb>, path: string, value: unknown) =>
+const dbSet = (db: ReturnType<typeof userDb>, path: string, value: unknown) =>
   db.ref(path).set(value);
 const dbUpdate = (
-  db: ReturnType<typeof authedDb>,
+  db: ReturnType<typeof userDb>,
   path: string,
   value: Record<string, unknown>,
 ) => db.ref(path).update(value);
-const dbRemove = (db: ReturnType<typeof authedDb>, path: string) =>
+const dbRemove = (db: ReturnType<typeof userDb>, path: string) =>
   db.ref(path).remove();
 
 describe("Realtime Database rules", () => {
@@ -66,10 +66,10 @@ describe("Realtime Database rules", () => {
           postContent: "seed post",
           timestamp: Date.now(),
           replyCount: 0,
-          // userId: uidA, // this is never needed anymore
+          // userId: uidCurrent, // this is never needed anymore
         },
-        [`authorLookup/${postId}`]: uidA, // this is now required! authorLookup is only accessible to admin, though
-        [`users/${uidA}/posts/${postId}`]: true,
+        [`authorLookup/${postId}`]: uidCurrent, // this is now required! authorLookup is only accessible to admin, though
+        [`users/${uidCurrent}/posts/${postId}`]: true,
       });
     });
   });
@@ -80,853 +80,262 @@ describe("Realtime Database rules", () => {
     }
   });
 
-  describe("Public + Legacy Read Access", () => {
-    // public access
-    it("allow public reads to posts/replies", async () => {
-      const db = unAuthedDb();
-      await assertSucceeds(dbGet(db, `posts/${postId}`));
-    });
+  describe("Reads", () => {
+    describe("Denied Reads", () => {
+      const sensitivePaths = [
+        "users",
+        `users/${uidCurrent}`,
+        `users/${uidCurrent}/posts`,
+        `users/${uidCurrent}/replies`,
+        `users/${uidCurrent}/notifications`,
+        `users/${uidCurrent}/subreplies`,
+        `users/${uidCurrent}/displayName`,
+        `users/${uidCurrent}/email`,
+        `users/${uidCurrent}/postInteractions`,
+      ];
 
-    // TODO: after full data migration add test that ensures userId is NEVER in
-    // any post/reply/subreply data
-    //
-    // it("public post data contains only userId and not private metadata", async () => {
-    //   const db = anonDb();
-    //   const snap = await dbGet(db, `posts/${postId}`);
-    //   expect(snap.child("userId").exists()).toBe(true);
-    //   expect(snap.child("notifications").exists()).toBe(false);
-    // });
-  });
-
-  describe("Unauthorized Reads", () => {
-    // unauthorized access
-    it("denies unauthorized access to root users list (preventing ID scraping)", async () => {
-      const dbPublic = unAuthedDb();
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbPublic, "users"));
-      await assertFails(dbGet(dbB, "users"));
-    });
-
-    // unauthorized access
-    it("denies anonymous access to a user's private profile data", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}`));
-    });
-
-    it("denies anonymous access to a user's posts", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}/posts`));
-    });
-
-    it("denies anonymous access to a user's replies", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}/replies`));
-    });
-
-    it("denies anonymous access to a user's notifications", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}/notifications`));
-    });
-
-    it("denies anonymous access to a user's displayName", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}/displayName`));
-    });
-
-    it("denies anonymous access to a user's email", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}/email`));
-    });
-
-    it("denies anonymous access to a user's postInteractions (legacy field)", async () => {
-      const dbPublic = unAuthedDb();
-      await assertFails(dbGet(dbPublic, `users/${uidA}/postInteractions`));
-    });
-
-    it("denies other user access to a user's posts", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbB, `users/${uidA}/posts`));
-    });
-
-    it("denies other user access to a user's replies", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbB, `users/${uidA}/replies`));
-    });
-
-    it("denies other user access to a user's notifications", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbB, `users/${uidA}/notifications`));
-    });
-
-    it("denies other user access to a user's displayName", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbB, `users/${uidA}/displayName`));
-    });
-
-    it("denies other user access to a user's email", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbB, `users/${uidA}/email`));
-    });
-
-    it("denies other user access to a user's postInteractions (legacy field)", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbB, `users/${uidA}/postInteractions`));
-    });
-  });
-
-  describe("Unauthorized Writes", () => {
-    it("denies unauthenticated user post creation", async () => {
-      const db = unAuthedDb();
-      await assertFails(
-        dbSet(db, "posts/post_x", {
-          postContent: "anon write",
-          timestamp: Date.now(),
-          replyCount: 0,
-        }),
-      );
-    });
-
-    it("denies users from writing to another user's profile/index", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(dbSet(dbB, `users/${uidA}/posts/evil`, true));
-    });
-
-    it("denies any user from writing to reply count", async () => {
-      const dbA = authedDb(uidA);
-      const dbB = authedDb(uidB);
-
-      // this is the author
-      await assertFails(dbSet(dbA, `posts/${postId}/replyCount`, 999));
-      // this is a random user
-      await assertFails(dbSet(dbB, `posts/${postId}/replyCount`, 123));
-    });
-  });
-
-  describe("Authorized Read + Write", () => {
-    it("allows users to read/write their own users tree", async () => {
-      const dbA = authedDb(uidA);
-      await assertSucceeds(
-        dbSet(dbA, `users/${uidA}/notifications/test`, {
-          type: "reply",
-          isRead: false,
-          updatedAt: Date.now(),
-        }),
-      );
-      await assertSucceeds(dbGet(dbA, `users/${uidA}`));
-    });
-  });
-
-  describe("Anonymous Post Creation + Deletion", () => {
-    it("denies creating a anonymous post without linking to users/", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_post_123";
-
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`posts/${anonPostId}`]: {
-            id: anonPostId,
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            // userId is omitted here for anonymity
-          },
-          // no write to users/
-        }),
-      );
-    });
-
-    it("allows creating a post without a public userId (Anonymous Post)", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_post_123";
-
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`posts/${anonPostId}`]: {
-            id: anonPostId,
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            // userId is omitted here for anonymity
-          },
-          [`users/${uidA}/posts/${anonPostId}`]: true,
-        }),
-      );
-    });
-
-    it("allows deleting a post created anonymously", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_to_delete";
-
-      // seed an anonymous post with no userId field, but indexed for user_a
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`posts/${anonPostId}`]: {
-            postContent: "hidden author",
-            timestamp: Date.now(),
-            replyCount: 0,
-          },
-          [`users/${uidA}/posts/${anonPostId}`]: true,
+      describe("by Guest User", () => {
+        it.each(sensitivePaths)("access to %s", async (path) => {
+          await assertFails(dbGet(guestDb(), path));
         });
       });
 
-      // note that both paths must be deleted together
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`posts/${anonPostId}`]: null,
-          [`users/${uidA}/posts/${anonPostId}`]: null,
-        }),
-      );
+      describe("by (other) Authenticated User", () => {
+        it.each(sensitivePaths)("access to %s", async (path) => {
+          await assertFails(dbGet(userDb(uidOther), path));
+        });
+      });
+
+      it("denies access to the authorLookup tree by anyone", async () => {
+        await assertFails(dbGet(guestDb(), "authorLookup"));
+        await assertFails(dbGet(guestDb(), `authorLookup/${postId}`));
+        await assertFails(dbGet(userDb(uidOther), `authorLookup/${postId}`));
+        await assertFails(dbGet(userDb(uidCurrent), `authorLookup/${postId}`)); // even author doesn't have access
+      });
+    });
+
+    describe("Allowed Reads", () => {
+      const subReplyId = "sub_1";
+
+      beforeAll(async () => {
+        // seed the reply and sub-reply for testing read access
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+          const db = dbFromContext(context);
+          await dbUpdate(db, "/", {
+            [`replies/${postId}/${replyId}`]: {
+              id: replyId,
+              postContent: "seed reply",
+              timestamp: Date.now(),
+              parentPostId: postId,
+              replyCount: 0,
+              interactionScore: 0,
+            },
+            [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
+              id: subReplyId,
+              postContent: "seed sub-reply",
+              timestamp: Date.now(),
+              parentPostId: postId,
+              parentReplyId: replyId,
+              authorDisplay: "Anonymous User",
+            },
+          });
+        });
+      });
+
+      // we use a getter function (getDb) to defer initialization until runtime
+      const roles = [
+        { name: "Guest", getDb: () => guestDb() },
+        { name: "Other User", getDb: () => userDb(uidOther) },
+        { name: "Current User (Owner)", getDb: () => userDb(uidCurrent) },
+      ];
+
+      const publicPaths = [
+        `posts/${postId}`,
+        `replies/${postId}/${replyId}`,
+        `subreplies/${postId}/${replyId}/${subReplyId}`,
+      ];
+
+      // check all roles against all public paths
+      roles.forEach(({ name, getDb }) => {
+        it.each(publicPaths)(`allows ${name} to read %s`, async (path) => {
+          // getDb() is called here, safely inside the execution phase
+          const db = getDb();
+          const snap = await assertSucceeds(dbGet(db, path));
+          expect(snap.exists()).toBe(true);
+          // system check: ensure userId is NOT leaked in the public read
+          expect(snap.child("userId").exists()).toBe(false);
+        });
+      });
+
+      it("allows Current User to read their own users/ tree (profile, receipts, and notifications)", async () => {
+        const dbCurrent = userDb(uidCurrent);
+        const snap = await assertSucceeds(
+          dbGet(dbCurrent, `users/${uidCurrent}`),
+        );
+        expect(snap.exists()).toBe(true);
+      });
     });
   });
 
-  describe("Non-Anonymous Post Creation + Deletion", () => {
-    it("allows creating a post with required fields (legacy format)", async () => {
-      const dbA = authedDb(uidA);
-      const newPost = "post_new";
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`posts/${newPost}`]: {
-            id: newPost,
-            userId: uidA,
-            postContent: "hello world",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-          },
-          [`users/${uidA}/posts/${newPost}`]: true, // this is REQUIRED
-        }),
-      );
-    });
+  describe("Writes", () => {
+    describe("To Protected Fields", () => {
+      describe("Denied Writes", () => {
+        // 1. Check that replyCount is protected from everyone except the system (Cloud Functions)
+        // We test both Guests and Other Users. Even the Owner is denied (tested in the previous block).
+        it.each([
+          { role: "Guest", getDb: () => guestDb() },
+          { role: "Other User", getDb: () => userDb(uidOther) },
+        ])(
+          "denies $role from writing to replyCount on posts and replies",
+          async ({ getDb }) => {
+            const db = getDb();
 
-    it("denies post creation with mismatched userId linkage", async () => {
-      const dbA = authedDb(uidA);
-      const newPost = "post_wrong_uid";
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`posts/${newPost}`]: {
-            id: newPost,
-            userId: uidB,
-            postContent: "wrong userId",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-          },
-          [`users/${uidA}/posts/${newPost}`]: true,
-        }),
-      );
-    });
+            // Attempting to overwrite the counter directly
+            await assertFails(dbSet(db, `posts/${postId}/replyCount`, 99));
+            await assertFails(
+              dbSet(db, `replies/${postId}/${replyId}/replyCount`, 99),
+            );
 
-    it("denies post creation when required fields are missing", async () => {
-      const dbA = authedDb(uidA);
-      const newPost = "post_missing_fields";
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`posts/${newPost}`]: {
-            id: newPost,
-            userId: uidA,
-            postContent: "missing fields",
-            // missing timestamp, reply count
+            // Attempting an update on just that field
+            await assertFails(
+              dbUpdate(db, `posts/${postId}`, { replyCount: 1 }),
+            );
           },
-          [`users/${uidA}/posts/${newPost}`]: true,
-        }),
-      );
-    });
+        );
 
-    it("allows deleting a post created non-anonymously", async () => {
-      const dbA = authedDb(uidA);
-      const nonAnonPostId = "non-anonymous-user";
-
-      // seed an anonymous post with no userId field, but indexed for user_a
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`posts/${nonAnonPostId}`]: {
-            userId: nonAnonPostId,
-            postContent: "not anonymous!",
-            timestamp: Date.now(),
-            replyCount: 0,
+        // 2. Ensure Guest users (public) cannot write to any content paths
+        it.each([
+          { path: `posts/new_post`, label: "top-level posts" },
+          { path: `replies/${postId}/new_reply`, label: "replies" },
+          {
+            path: `subreplies/${postId}/${replyId}/new_sub`,
+            label: "sub-replies",
           },
-          [`users/${uidA}/posts/${nonAnonPostId}`]: true,
+        ])("denies Guest from writing to $label", async ({ path }) => {
+          const db = guestDb();
+
+          await assertFails(
+            dbSet(db, path, {
+              postContent: "I am a guest",
+              timestamp: Date.now(),
+            }),
+          );
+        });
+
+        // 3. Ensure no user can write to the 'id' field specifically
+        // (This protects the internal document integrity)
+        it("denies Other User from overwriting an existing post's internal ID", async () => {
+          const db = userDb(uidOther);
+
+          await assertFails(
+            dbUpdate(db, `posts/${postId}`, {
+              id: "different_id",
+            }),
+          );
         });
       });
 
-      // note that both paths must be deleted together
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`posts/${nonAnonPostId}`]: null,
-          [`users/${uidA}/posts/${nonAnonPostId}`]: null,
-        }),
-      );
-    });
+      describe("Allowed Writes", () => {
+        it("allows current user to update isRead status of their notification", async () => {
+          const notifId = "notif_test_123";
+          const notifPath = `users/${uidCurrent}/notifications/${notifId}`;
 
-    it("denies post creation if content exceeds 600 chars", async () => {
-      const dbA = authedDb(uidA);
-      const newPost = "post_too_long";
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`posts/${newPost}`]: {
-            id: newPost,
-            userId: uidA,
-            postContent: "x".repeat(601),
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-          },
-          [`users/${uidA}/posts/${newPost}`]: true,
-        }),
-      );
-    });
-  });
+          // seed a notification first
+          await testEnv.withSecurityRulesDisabled(async (context) => {
+            const db = dbFromContext(context);
+            await dbSet(db, notifPath, {
+              type: "reply",
+              isRead: false,
+              count: 1,
+              updatedAt: Date.now(),
+              createdAt: Date.now(),
+            });
+          });
 
-  describe("General Reply Validation", () => {
-    it("denies reply with out-of-range interactionScore", async () => {
-      const dbA = authedDb(uidA);
-      const outOfRangeReply = "reply_out_of_range";
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${outOfRangeReply}`]: {
-            id: outOfRangeReply,
-            userId: uidA,
-            postContent: "bad score",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 7,
-          },
-        }),
-      );
-    });
-
-    it("denies reply if userId doesn't match auth.uid", async () => {
-      const dbA = authedDb(uidA);
-      const wrongUidReply = "reply_wrong_uid";
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${wrongUidReply}`]: {
-            id: wrongUidReply,
-            userId: uidB,
-            postContent: "wrong uid",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 1,
-          },
-        }),
-      );
-    });
-
-    it("denies owner reply if content exceeds 600 chars", async () => {
-      const dbA = authedDb(uidA);
-      const longReply = "reply_too_long";
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${longReply}`]: {
-            id: longReply,
-            userId: uidA,
-            postContent: "x".repeat(601),
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 1,
-          },
-        }),
-      );
-    });
-  });
-
-  describe("Anonymous Reply Creation + Deletion", () => {
-    it("denies creating a anonymous reply without interaction score", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_post_123";
-
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${anonPostId}`]: {
-            id: anonPostId,
-            // userId is omitted here for anonymity
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            // interactionScore: 2,
-          },
-          [`users/${uidA}/replies/${postId}/${anonPostId}`]: true,
-        }),
-      );
-    });
-
-    it("denies creating a anonymous reply without linking to users/", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_post_123";
-
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${anonPostId}`]: {
-            id: anonPostId,
-            // userId is omitted here for anonymity
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          // [`users/${uidA}/replies/${postId}/${anonPostId}`]: true,
-        }),
-      );
-    });
-
-    it("allows creating a anonymous self-reply with required fields", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_self_reply";
-
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${anonPostId}`]: {
-            id: anonPostId,
-            // userId is omitted here for anonymity
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidA}/replies/${postId}/${anonPostId}`]: true,
-        }),
-      );
-    });
-
-    it("allows creating a anonymous reply with required fields", async () => {
-      const dbB = authedDb(uidB);
-      const anonPostId = "anon_post_123";
-
-      await assertSucceeds(
-        dbUpdate(dbB, "/", {
-          [`replies/${postId}/${anonPostId}`]: {
-            id: anonPostId,
-            // userId is omitted here for anonymity
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidB}/replies/${postId}/${anonPostId}`]: true,
-        }),
-      );
-    });
-
-    it("allows deleting an anonymous reply with required fields", async () => {
-      const dbA = authedDb(uidA);
-      const anonPostId = "anon_to_delete";
-
-      // seed an anonymous reply with no userId field, but indexed for user_a
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`replies/${postId}/${anonPostId}`]: {
-            id: anonPostId,
-            // userId is omitted here for anonymity
-            postContent: "this is anonymous",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidA}/replies/${postId}/${anonPostId}`]: true,
+          // owner should be able to mark it as read
+          // this satisfies the .validate requirement for type, isRead, and updatedAt
+          await assertSucceeds(
+            dbUpdate(userDb(uidCurrent), notifPath, {
+              isRead: true,
+              updatedAt: Date.now(),
+            }),
+          );
         });
       });
 
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${anonPostId}`]: null,
-          [`users/${uidA}/replies/${postId}/${anonPostId}`]: null,
-        }),
-      );
-    });
-  });
+      describe("To Protected Fields", () => {
+        describe("Denied Writes", () => {
+          // Parameterized check for replyCount - even the owner is denied
+          // because this is managed by Cloud Functions.
+          it.each([
+            { role: "Guest", getDb: () => guestDb() },
+            { role: "Other User", getDb: () => userDb(uidOther) },
+            { role: "Owner", getDb: () => userDb(uidCurrent) },
+          ])(
+            "denies $role from modifying replyCount on posts or replies",
+            async ({ getDb }) => {
+              const db = getDb();
+              await assertFails(dbSet(db, `posts/${postId}/replyCount`, 10));
+              await assertFails(
+                dbSet(db, `replies/${postId}/${replyId}/replyCount`, 5),
+              );
+            },
+          );
 
-  describe("Non-Anonymous Reply Creation + Deletion", () => {
-    it("denies creating a non-anonymous reply without interaction score", async () => {
-      const dbB = authedDb(uidB);
+          // Verifying ID immutability and path-key matching
+          it("denies a user from changing internal 'id' fields to mismatch the path key", async () => {
+            const subReplyPath = `subreplies/${postId}/${replyId}/sub_target`;
 
-      await assertFails(
-        dbUpdate(dbB, "/", {
-          [`replies/${postId}/${replyId}`]: {
-            id: replyId,
-            userId: uidB,
-            postContent: "no score here",
-            timestamp: Date.now(),
-            replyCount: 0,
-            parentPostId: postId,
-            // interactionScore is missing!
-          },
-          [`users/${uidB}/replies/${postId}/${replyId}`]: true,
-        }),
-      );
-    });
+            // Seed the sub-reply
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+              const db = dbFromContext(context);
+              await dbUpdate(db, "/", {
+                [subReplyPath]: {
+                  id: "sub_target",
+                  postContent: "original",
+                  authorDisplay: "Anon",
+                },
+                [`authorLookup/sub_target`]: uidCurrent,
+                [`users/${uidCurrent}/${subReplyPath}`]: true,
+              });
+            });
 
-    it("denies creating a non-anonymous reply without linking to users/", async () => {
-      const dbB = authedDb(uidB);
-      await assertFails(
-        // Trying to write only to the public tree without the private index
-        dbSet(dbB, `replies/${postId}/${replyId}`, {
-          id: replyId,
-          userId: uidB,
-          postContent: "trying to skip the index",
-          timestamp: Date.now(),
-          replyCount: 0,
-          parentPostId: postId,
-          interactionScore: 1,
-        }),
-      );
-    });
+            // Attempt to change the internal ID while keeping the path the same
+            await assertFails(
+              dbUpdate(userDb(uidCurrent), subReplyPath, {
+                id: "malicious_id_swap",
+              }),
+            );
+          });
+        });
 
-    it("allows creating non-anonymous self-reply with required fields", async () => {
-      const dbA = authedDb(uidA);
-      const ownerReply = "reply_owner";
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`replies/${postId}/${ownerReply}`]: {
-            id: ownerReply,
-            userId: uidA,
-            postContent: "owner reply",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidA}/replies/${postId}/${ownerReply}`]: true,
-        }),
-      );
-    });
+        describe("Allowed Writes", () => {
+          it("allows current user to update the isRead status of their own notification", async () => {
+            const notifId = "notif_test_123";
+            const notifPath = `users/${uidCurrent}/notifications/${notifId}`;
 
-    it("allows creating non-anonymous reply with required fields", async () => {
-      const dbB = authedDb(uidB);
+            // Seed a notification
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+              const db = dbFromContext(context);
+              await dbSet(db, notifPath, {
+                type: "reply",
+                isRead: false,
+                count: 1,
+                updatedAt: Date.now(),
+                createdAt: Date.now(),
+              });
+            });
 
-      await assertSucceeds(
-        dbUpdate(dbB, "/", {
-          [`replies/${postId}/${replyId}`]: {
-            id: replyId,
-            userId: uidB,
-            postContent: "reply body",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidB}/replies/${postId}/${replyId}`]: true,
-        }),
-      );
-    });
-
-    it("allows deleting non-anonymous reply with required fields", async () => {
-      const dbB = authedDb(uidB);
-
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`replies/${postId}/${replyId}`]: {
-            id: replyId,
-            userId: uidB,
-            postContent: "reply body",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidB}/replies/${postId}/${replyId}`]: true,
+            // System Check: User should be able to toggle isRead without affecting other fields
+            await assertSucceeds(
+              dbUpdate(userDb(uidCurrent), notifPath, {
+                isRead: true,
+                updatedAt: Date.now(),
+              }),
+            );
+          });
         });
       });
-
-      await assertSucceeds(
-        dbUpdate(dbB, "/", {
-          [`replies/${postId}/${replyId}`]: null,
-          [`users/${uidB}/replies/${postId}/${replyId}`]: null,
-        }),
-      );
-    });
-  });
-
-  describe("Update & Deletion Security", () => {
-    it("allows owner to edit postContent and denies non-owner", async () => {
-      const dbA = authedDb(uidA);
-      const dbB = authedDb(uidB);
-      const newContent = "this is edited content";
-
-      // check that the owner (User A) can edit their own post
-      await assertSucceeds(
-        dbUpdate(dbA, `posts/${postId}`, {
-          postContent: newContent,
-        }),
-      );
-
-      // check that a non-owner (User B) cannot edit User A's post
-      await assertFails(
-        dbUpdate(dbB, `posts/${postId}`, {
-          postContent: "malicious edit",
-        }),
-      );
-    });
-
-    it("allows owner delete and denies non-owner delete", async () => {
-      const dbA = authedDb(uidA);
-      const dbB = authedDb(uidB);
-
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`posts/${postId}`]: null,
-          [`users/${uidA}/posts/${postId}`]: null,
-        }),
-      );
-
-      // Re-seed post
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`posts/${postId}`]: {
-            postContent: "seed post",
-            timestamp: Date.now(),
-            replyCount: 0,
-            userId: uidA,
-          },
-          [`users/${uidA}/posts/${postId}`]: true,
-        });
-      });
-
-      await assertFails(
-        dbUpdate(dbB, "/", {
-          [`posts/${postId}`]: null,
-          [`users/${uidA}/posts/${postId}`]: null,
-        }),
-      );
-    });
-
-    it("denies User B from deleting User A's anonymous post", async () => {
-      const dbB = authedDb(uidB);
-      const anonPostId = "uidA_secret_post";
-
-      // Setup: Post belongs to User A (via index), but is anonymous publicly
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`posts/${anonPostId}`]: {
-            postContent: "Anonymous but owned by A",
-            timestamp: Date.now(),
-            replyCount: 0,
-          },
-          [`users/${uidA}/posts/${anonPostId}`]: true,
-        });
-      });
-
-      // User B tries to delete the post and their own fake index
-      await assertFails(
-        dbUpdate(dbB, "/", {
-          [`posts/${anonPostId}`]: null,
-          [`users/${uidB}/posts/${anonPostId}`]: null,
-        }),
-      );
-    });
-
-    it("denies deleting reply without receipt or main object cleanup", async () => {
-      const dbB = authedDb(uidB);
-
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`replies/${postId}/${replyId}`]: {
-            id: replyId,
-            userId: uidB,
-            postContent: "reply body",
-            timestamp: { ".sv": "timestamp" },
-            replyCount: 0,
-            parentPostId: postId,
-            interactionScore: 2,
-          },
-          [`users/${uidB}/replies/${postId}/${replyId}`]: true,
-        });
-      });
-
-      // note that remove does the same thing as : null underneath
-      await assertFails(
-        dbRemove(dbB, `users/${uidB}/replies/${postId}/${replyId}`),
-      );
-      await assertFails(
-        dbUpdate(dbB, "/", {
-          [`users/${uidB}/replies/${postId}/${replyId}`]: null,
-        }),
-      );
-
-      // note that remove does the same thing as : null underneath
-      await assertFails(dbRemove(dbB, `replies/${postId}/${replyId}`));
-      await assertFails(
-        dbUpdate(dbB, "/", {
-          [`replies/${postId}/${replyId}`]: null,
-        }),
-      );
-    });
-
-    it("allows 'lazy cleanup' of a dangling receipt when the public post is already gone", async () => {
-      const dbA = authedDb(uidA);
-      const orphanPostId = "orphan_post_999";
-
-      // create an orphan (receipt exists, but public post is null/missing)
-      // mimics a thread author deleting a post, leaving our receipt dangling
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`users/${uidA}/posts/${orphanPostId}`]: true,
-          // note: we do NOT create posts/${orphanPostId} here
-        });
-      });
-
-      // this should succeed: the rules see the public post is already gone,
-      // so deleting the receipt restores consistency (the "self-healing" path)
-      await assertSucceeds(
-        dbRemove(dbA, `users/${uidA}/posts/${orphanPostId}`),
-      );
-    });
-
-    it("allows 'lazy cleanup' of a dangling reply receipt when the public thread is gone", async () => {
-      const dbB = authedDb(uidB);
-      const orphanReplyId = "orphan_reply_888";
-      const deadPostId = "dead_parent_post";
-
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`users/${uidB}/replies/${deadPostId}/${orphanReplyId}`]: true,
-          // public replies tree is empty/null
-        });
-      });
-
-      // client performs self-healing cleanup
-      await assertSucceeds(
-        dbRemove(dbB, `users/${uidB}/replies/${deadPostId}/${orphanReplyId}`),
-      );
-    });
-  });
-
-  describe("Sub-Reply Read Access", () => {
-    const subReplyId = "subreply_read_1";
-
-    beforeEach(async () => {
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "a sub-reply",
-            timestamp: Date.now(),
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        });
-      });
-    });
-
-    it("allows unauthenticated reads to subreplies/", async () => {
-      const db = unAuthedDb();
-      await assertSucceeds(
-        dbGet(db, `subreplies/${postId}/${replyId}/${subReplyId}`),
-      );
-    });
-
-    it("allows authenticated reads to subreplies/", async () => {
-      const db = authedDb(uidB);
-      await assertSucceeds(
-        dbGet(db, `subreplies/${postId}/${replyId}/${subReplyId}`),
-      );
-    });
-  });
-
-  describe("Anonymous Sub-Reply Creation + Deletion", () => {
-    const subReplyId = "subreply_anon_1";
-
-    it("denies creating an anonymous sub-reply without a receipt", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "missing receipt",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          // no users/ receipt
-        }),
-      );
-    });
-
-    it("denies creating a receipt without the main subreply object", async () => {
-      const dbA = authedDb(uidA);
-      await assertFails(
-        dbUpdate(dbA, "/", {
-          // no subreplies/ object
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("allows creating an anonymous sub-reply with required fields + receipt", async () => {
-      const dbA = authedDb(uidA);
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "anonymous sub-reply",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        }),
-      );
-    });
-
-    it("allows another user to create an anonymous sub-reply", async () => {
-      const dbB = authedDb(uidB);
-      const subReplyIdB = "subreply_anon_user_b"; // distinct ID — avoids state from prior test
-      await assertSucceeds(
-        dbUpdate(dbB, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyIdB}`]: {
-            id: subReplyIdB,
-            postContent: "user B anonymous sub",
-            timestamp: { ".sv": "timestamp" },
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidB}/subreplies/${postId}/${replyId}/${subReplyIdB}`]: true,
-        }),
-      );
-    });
-
-    it("allows deleting an anonymous sub-reply with receipt", async () => {
-      const dbA = authedDb(uidA);
-      await testEnv.withSecurityRulesDisabled(async (context) => {
-        const db = dbFromContext(context);
-        await dbUpdate(db, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: {
-            id: subReplyId,
-            postContent: "to delete",
-            timestamp: Date.now(),
-            parentPostId: postId,
-            parentReplyId: replyId,
-            authorDisplay: "Anonymous User",
-          },
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: true,
-        });
-      });
-
-      await assertSucceeds(
-        dbUpdate(dbA, "/", {
-          [`subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-          [`users/${uidA}/subreplies/${postId}/${replyId}/${subReplyId}`]: null,
-        }),
-      );
     });
 
     it("denies deleting only the sub-reply object (without receipt)", async () => {

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -180,30 +180,29 @@ describe("Realtime Database rules", () => {
   describe("Writes (create/delete)", () => {
     describe("To Protected Fields", () => {
       describe("Denied Writes", () => {
-        // 1. Check that replyCount is protected from everyone except the system (Cloud Functions)
-        // We test both Guests and Other Users. Even the Owner is denied (tested in the previous block).
         it.each([
           { role: "Guest", getDb: () => guestDb() },
           { role: "Other User", getDb: () => userDb(uidOther) },
+          { role: "Owner", getDb: () => userDb(uidCurrent) },
         ])(
-          "denies $role from writing to replyCount on posts and replies",
+          "denies $role from modifying replyCount on posts or replies",
           async ({ getDb }) => {
             const db = getDb();
 
-            // Attempting to overwrite the counter directly
+            // attempt overwrite
             await assertFails(dbSet(db, `posts/${postId}/replyCount`, 99));
             await assertFails(
               dbSet(db, `replies/${postId}/${replyId}/replyCount`, 99),
             );
 
-            // Attempting an update on just that field
+            // attempt partial update
             await assertFails(
               dbUpdate(db, `posts/${postId}`, { replyCount: 1 }),
             );
           },
         );
 
-        // 2. Ensure Guest users (public) cannot write to any content paths
+        // ensure guest users cannot write to any content paths
         it.each([
           { path: `posts/new_post`, label: "top-level posts" },
           { path: `replies/${postId}/new_reply`, label: "replies" },
@@ -222,14 +221,28 @@ describe("Realtime Database rules", () => {
           );
         });
 
-        // 3. Ensure no user can write to the 'id' field specifically
-        // (This protects the internal document integrity)
-        it("denies Other User from overwriting an existing post's internal ID", async () => {
-          const db = userDb(uidOther);
+        // verify id immutability and path-key matching
+        it("denies users from changing internal 'id' fields", async () => {
+          const subReplyPath = `subreplies/${postId}/${replyId}/sub_target`;
 
+          // seed the sub-reply
+          await testEnv.withSecurityRulesDisabled(async (context) => {
+            const db = dbFromContext(context);
+            await dbUpdate(db, "/", {
+              [subReplyPath]: {
+                id: "sub_target",
+                postContent: "original",
+                authorDisplay: "Anon",
+              },
+              [`authorLookup/sub_target`]: uidCurrent,
+              [`users/${uidCurrent}/${subReplyPath}`]: true,
+            });
+          });
+
+          // attempt to change the internal id
           await assertFails(
-            dbUpdate(db, `posts/${postId}`, {
-              id: "different_id",
+            dbUpdate(userDb(uidCurrent), subReplyPath, {
+              id: "malicious_id_swap",
             }),
           );
         });
@@ -253,87 +266,12 @@ describe("Realtime Database rules", () => {
           });
 
           // owner should be able to mark it as read
-          // this satisfies the .validate requirement for type, isRead, and updatedAt
           await assertSucceeds(
             dbUpdate(userDb(uidCurrent), notifPath, {
               isRead: true,
               updatedAt: Date.now(),
             }),
           );
-        });
-      });
-
-      describe("To Protected Fields", () => {
-        describe("Denied Writes", () => {
-          // Parameterized check for replyCount - even the owner is denied
-          // because this is managed by Cloud Functions.
-          it.each([
-            { role: "Guest", getDb: () => guestDb() },
-            { role: "Other User", getDb: () => userDb(uidOther) },
-            { role: "Owner", getDb: () => userDb(uidCurrent) },
-          ])(
-            "denies $role from modifying replyCount on posts or replies",
-            async ({ getDb }) => {
-              const db = getDb();
-              await assertFails(dbSet(db, `posts/${postId}/replyCount`, 10));
-              await assertFails(
-                dbSet(db, `replies/${postId}/${replyId}/replyCount`, 5),
-              );
-            },
-          );
-
-          // Verifying ID immutability and path-key matching
-          it("denies a user from changing internal 'id' fields to mismatch the path key", async () => {
-            const subReplyPath = `subreplies/${postId}/${replyId}/sub_target`;
-
-            // Seed the sub-reply
-            await testEnv.withSecurityRulesDisabled(async (context) => {
-              const db = dbFromContext(context);
-              await dbUpdate(db, "/", {
-                [subReplyPath]: {
-                  id: "sub_target",
-                  postContent: "original",
-                  authorDisplay: "Anon",
-                },
-                [`authorLookup/sub_target`]: uidCurrent,
-                [`users/${uidCurrent}/${subReplyPath}`]: true,
-              });
-            });
-
-            // Attempt to change the internal ID while keeping the path the same
-            await assertFails(
-              dbUpdate(userDb(uidCurrent), subReplyPath, {
-                id: "malicious_id_swap",
-              }),
-            );
-          });
-        });
-
-        describe("Allowed Writes", () => {
-          it("allows current user to update the isRead status of their own notification", async () => {
-            const notifId = "notif_test_123";
-            const notifPath = `users/${uidCurrent}/notifications/${notifId}`;
-
-            // Seed a notification
-            await testEnv.withSecurityRulesDisabled(async (context) => {
-              const db = dbFromContext(context);
-              await dbSet(db, notifPath, {
-                type: "reply",
-                isRead: false,
-                count: 1,
-                updatedAt: Date.now(),
-                createdAt: Date.now(),
-              });
-            });
-
-            // System Check: User should be able to toggle isRead without affecting other fields
-            await assertSucceeds(
-              dbUpdate(userDb(uidCurrent), notifPath, {
-                isRead: true,
-                updatedAt: Date.now(),
-              }),
-            );
-          });
         });
       });
     });

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -36,8 +36,6 @@ const dbUpdate = (
   path: string,
   value: Record<string, unknown>,
 ) => db.ref(path).update(value);
-const dbRemove = (db: ReturnType<typeof userDb>, path: string) =>
-  db.ref(path).remove();
 
 describe("Realtime Database rules", () => {
   beforeAll(async () => {

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -9,6 +9,8 @@ import {
   initializeTestEnvironment,
 } from "@firebase/rules-unit-testing";
 
+// TODO: update rules to enforce thread author privacy lock
+
 const PROJECT_ID = "the-open-dissent-prod";
 const DB_NAME = "the-open-dissent-prod-default-rtdb";
 

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -87,22 +87,15 @@ describe("Realtime Database rules", () => {
       await assertSucceeds(dbGet(db, `posts/${postId}`));
     });
 
-    // legacy compatibility
-    it("legacy post shape still reads correctly (no authorDisplay/isThreadAuthor)", async () => {
-      const db = anonDb();
-      const snap = await assertSucceeds(dbGet(db, `posts/${postId}`));
-      expect(snap.exists()).toBe(true);
-      expect(snap.child("postContent").val()).toBe("seed post");
-      expect(snap.child("userId").val()).toBe(uidA);
-    });
-
-    // data security
-    it("public post data contains only userId and not private metadata", async () => {
-      const db = anonDb();
-      const snap = await dbGet(db, `posts/${postId}`);
-      expect(snap.child("userId").exists()).toBe(true);
-      expect(snap.child("notifications").exists()).toBe(false);
-    });
+    // TODO: after full data migration add test that ensures userId is NEVER in
+    // any post/reply/subreply data
+    //
+    // it("public post data contains only userId and not private metadata", async () => {
+    //   const db = anonDb();
+    //   const snap = await dbGet(db, `posts/${postId}`);
+    //   expect(snap.child("userId").exists()).toBe(true);
+    //   expect(snap.child("notifications").exists()).toBe(false);
+    // });
   });
 
   describe("Unauthorized Reads", () => {

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -101,46 +101,46 @@ describe("Realtime Database rules", () => {
   describe("Unauthorized Reads", () => {
     // unauthorized access
     it("denies unauthorized access to root users list (preventing ID scraping)", async () => {
-      const dbAnon = unAuthedDb();
+      const dbPublic = unAuthedDb();
       const dbB = authedDb(uidB);
-      await assertFails(dbGet(dbAnon, "users"));
+      await assertFails(dbGet(dbPublic, "users"));
       await assertFails(dbGet(dbB, "users"));
     });
 
     // unauthorized access
     it("denies anonymous access to a user's private profile data", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}`));
     });
 
     it("denies anonymous access to a user's posts", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}/posts`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}/posts`));
     });
 
     it("denies anonymous access to a user's replies", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}/replies`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}/replies`));
     });
 
     it("denies anonymous access to a user's notifications", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}/notifications`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}/notifications`));
     });
 
     it("denies anonymous access to a user's displayName", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}/displayName`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}/displayName`));
     });
 
     it("denies anonymous access to a user's email", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}/email`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}/email`));
     });
 
     it("denies anonymous access to a user's postInteractions (legacy field)", async () => {
-      const dbAnon = unAuthedDb();
-      await assertFails(dbGet(dbAnon, `users/${uidA}/postInteractions`));
+      const dbPublic = unAuthedDb();
+      await assertFails(dbGet(dbPublic, `users/${uidA}/postInteractions`));
     });
 
     it("denies other user access to a user's posts", async () => {

--- a/tests/database.rules.test.ts
+++ b/tests/database.rules.test.ts
@@ -25,7 +25,7 @@ const dbFromContext = (context: RulesTestContext) =>
 const authedDb = (uid: string) =>
   dbFromContext(testEnv.authenticatedContext(uid));
 
-const anonDb = () => dbFromContext(testEnv.unauthenticatedContext());
+const unAuthedDb = () => dbFromContext(testEnv.unauthenticatedContext());
 
 const dbGet = (db: ReturnType<typeof authedDb>, path: string) =>
   db.ref(path).once("value");
@@ -83,7 +83,7 @@ describe("Realtime Database rules", () => {
   describe("Public + Legacy Read Access", () => {
     // public access
     it("allow public reads to posts/replies", async () => {
-      const db = anonDb();
+      const db = unAuthedDb();
       await assertSucceeds(dbGet(db, `posts/${postId}`));
     });
 
@@ -101,7 +101,7 @@ describe("Realtime Database rules", () => {
   describe("Unauthorized Reads", () => {
     // unauthorized access
     it("denies unauthorized access to root users list (preventing ID scraping)", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       const dbB = authedDb(uidB);
       await assertFails(dbGet(dbAnon, "users"));
       await assertFails(dbGet(dbB, "users"));
@@ -109,37 +109,37 @@ describe("Realtime Database rules", () => {
 
     // unauthorized access
     it("denies anonymous access to a user's private profile data", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}`));
     });
 
     it("denies anonymous access to a user's posts", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}/posts`));
     });
 
     it("denies anonymous access to a user's replies", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}/replies`));
     });
 
     it("denies anonymous access to a user's notifications", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}/notifications`));
     });
 
     it("denies anonymous access to a user's displayName", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}/displayName`));
     });
 
     it("denies anonymous access to a user's email", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}/email`));
     });
 
     it("denies anonymous access to a user's postInteractions (legacy field)", async () => {
-      const dbAnon = anonDb();
+      const dbAnon = unAuthedDb();
       await assertFails(dbGet(dbAnon, `users/${uidA}/postInteractions`));
     });
 
@@ -176,7 +176,7 @@ describe("Realtime Database rules", () => {
 
   describe("Unauthorized Writes", () => {
     it("denies unauthenticated user post creation", async () => {
-      const db = anonDb();
+      const db = unAuthedDb();
       await assertFails(
         dbSet(db, "posts/post_x", {
           postContent: "anon write",
@@ -825,7 +825,7 @@ describe("Realtime Database rules", () => {
     });
 
     it("allows unauthenticated reads to subreplies/", async () => {
-      const db = anonDb();
+      const db = unAuthedDb();
       await assertSucceeds(
         dbGet(db, `subreplies/${postId}/${replyId}/${subReplyId}`),
       );
@@ -1159,7 +1159,7 @@ describe("Realtime Database rules", () => {
     });
 
     it("denies unauthenticated sub-reply creation", async () => {
-      const db = anonDb();
+      const db = unAuthedDb();
       await assertFails(
         dbUpdate(db, "/", {
           [`subreplies/${postId}/${replyId}/${subReplyId}`]: {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,829 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  RulesTestEnvironment,
+  RulesTestContext,
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import {
+  buildCreateUpdates,
+  buildDeleteUpdates,
+  buildEditUpdates,
+  buildShareUrl,
+} from "../src/lib/updateBuilders.ts";
+
+const PROJECT_ID = "the-open-dissent-prod";
+const DB_NAME = "the-open-dissent-prod-default-rtdb";
+
+const uid = "user_a";
+const uidOther = "user_b";
+
+let testEnv: RulesTestEnvironment;
+
+const dbFromContext = (context: RulesTestContext) =>
+  context.database(`http://127.0.0.1:9000?ns=${DB_NAME}`);
+
+const userDb = (userId: string) =>
+  dbFromContext(testEnv.authenticatedContext(userId));
+
+const guestDb = () => dbFromContext(testEnv.unauthenticatedContext());
+
+const dbUpdate = (
+  db: ReturnType<typeof userDb>,
+  path: string,
+  value: Record<string, unknown>,
+) => db.ref(path).update(value);
+
+const dbGet = (db: ReturnType<typeof userDb>, path: string) =>
+  db.ref(path).once("value");
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe("Integration tests (updateBuilders + rules)", () => {
+  beforeAll(async () => {
+    const rules = readFileSync(
+      resolve(process.cwd(), "database.rules.json"),
+      "utf8",
+    );
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      database: { host: "127.0.0.1", port: 9000, rules },
+    });
+  });
+
+  afterAll(async () => {
+    if (testEnv) await testEnv.cleanup();
+  });
+
+  // =========================================================================
+  // CREATE TESTS
+  // =========================================================================
+
+  describe("Create", () => {
+    // Fresh DB for every create test
+    beforeEach(async () => {
+      await testEnv.clearDatabase();
+    });
+
+    // -- Posts ---------------------------------------------------------------
+
+    it("creates an anonymous post", async () => {
+      const updates = buildCreateUpdates({
+        key: "post_anon",
+        userId: uid,
+        content: "Hello world",
+        authorDisplay: "Anonymous User",
+      });
+
+      await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+      // verify content exists
+      const snap = await dbGet(guestDb(), "posts/post_anon");
+      expect(snap.exists()).toBe(true);
+      expect(snap.val().authorDisplay).toBe("Anonymous User");
+      expect(snap.val().postContent).toBe("Hello world");
+      expect(snap.child("userId").exists()).toBe(false);
+    });
+
+    it("creates a non-anonymous post", async () => {
+      const updates = buildCreateUpdates({
+        key: "post_named",
+        userId: uid,
+        content: "I have a name",
+        authorDisplay: "John Doe",
+      });
+
+      await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+      const snap = await dbGet(guestDb(), "posts/post_named");
+      expect(snap.exists()).toBe(true);
+      expect(snap.val().authorDisplay).toBe("John Doe");
+      expect(snap.child("userId").exists()).toBe(false);
+    });
+
+    // -- Replies ------------------------------------------------------------
+
+    describe("Replies", () => {
+      const parentPostId = "parent_post";
+
+      beforeEach(async () => {
+        // seed a parent post
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+          const db = dbFromContext(context);
+          await dbUpdate(db, "/", {
+            [`posts/${parentPostId}`]: {
+              postContent: "parent",
+              timestamp: Date.now(),
+              replyCount: 0,
+            },
+            [`authorLookup/${parentPostId}`]: { uid, type: "post" },
+            [`users/${uid}/posts/${parentPostId}`]: true,
+          });
+        });
+      });
+
+      it("creates an anonymous reply", async () => {
+        const updates = buildCreateUpdates({
+          key: "reply_anon",
+          userId: uid,
+          content: "Anonymous reply",
+          authorDisplay: "Anonymous User",
+          parentPostId,
+          score: 0,
+        });
+
+        await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+        const snap = await dbGet(
+          guestDb(),
+          `replies/${parentPostId}/reply_anon`,
+        );
+        expect(snap.exists()).toBe(true);
+        expect(snap.val().authorDisplay).toBe("Anonymous User");
+        expect(snap.val().parentPostId).toBe(parentPostId);
+      });
+
+      it("creates a non-anonymous reply", async () => {
+        const updates = buildCreateUpdates({
+          key: "reply_named",
+          userId: uid,
+          content: "Named reply",
+          authorDisplay: "Jane Smith",
+          parentPostId,
+          score: 2,
+        });
+
+        await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+        const snap = await dbGet(
+          guestDb(),
+          `replies/${parentPostId}/reply_named`,
+        );
+        expect(snap.exists()).toBe(true);
+        expect(snap.val().authorDisplay).toBe("Jane Smith");
+        expect(snap.val().interactionScore).toBe(2);
+      });
+
+      it("creates a thread-author reply (matching anonymity)", async () => {
+        const updates = buildCreateUpdates({
+          key: "reply_author",
+          userId: uid,
+          content: "Author chiming in",
+          authorDisplay: "Anonymous User",
+          parentPostId,
+          score: 0,
+          isThreadAuthor: true,
+        });
+
+        await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+        const snap = await dbGet(
+          guestDb(),
+          `replies/${parentPostId}/reply_author`,
+        );
+        expect(snap.val().isThreadAuthor).toBe(true);
+      });
+    });
+
+    // -- Sub-Replies --------------------------------------------------------
+
+    describe("Sub-Replies", () => {
+      const parentPostId = "root_post";
+      const parentReplyId = "parent_reply";
+
+      beforeEach(async () => {
+        // seed root post + parent reply
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+          const db = dbFromContext(context);
+          await dbUpdate(db, "/", {
+            [`posts/${parentPostId}`]: {
+              postContent: "root",
+              timestamp: Date.now(),
+              replyCount: 1,
+            },
+            [`authorLookup/${parentPostId}`]: { uid, type: "post" },
+            [`users/${uid}/posts/${parentPostId}`]: true,
+            [`replies/${parentPostId}/${parentReplyId}`]: {
+              id: parentReplyId,
+              postContent: "reply",
+              timestamp: Date.now(),
+              parentPostId,
+              replyCount: 0,
+              interactionScore: 0,
+            },
+            [`authorLookup/${parentReplyId}`]: {
+              uid,
+              type: "reply",
+              postId: parentPostId,
+            },
+            [`users/${uid}/replies/${parentPostId}/${parentReplyId}`]: true,
+          });
+        });
+      });
+
+      it("creates an anonymous sub-reply", async () => {
+        const updates = buildCreateUpdates({
+          key: "sub_anon",
+          userId: uidOther,
+          content: "Anon sub-reply",
+          authorDisplay: "Anonymous User",
+          parentPostId,
+          parentReplyId,
+        });
+
+        await assertSucceeds(dbUpdate(userDb(uidOther), "/", updates));
+
+        const snap = await dbGet(
+          guestDb(),
+          `subreplies/${parentPostId}/${parentReplyId}/sub_anon`,
+        );
+        expect(snap.exists()).toBe(true);
+        expect(snap.val().authorDisplay).toBe("Anonymous User");
+      });
+
+      it("creates a non-anonymous sub-reply", async () => {
+        const updates = buildCreateUpdates({
+          key: "sub_named",
+          userId: uidOther,
+          content: "Named sub-reply",
+          authorDisplay: "Bob Builder",
+          parentPostId,
+          parentReplyId,
+        });
+
+        await assertSucceeds(dbUpdate(userDb(uidOther), "/", updates));
+
+        const snap = await dbGet(
+          guestDb(),
+          `subreplies/${parentPostId}/${parentReplyId}/sub_named`,
+        );
+        expect(snap.val().authorDisplay).toBe("Bob Builder");
+      });
+    });
+  });
+
+  // =========================================================================
+  // DELETE TESTS
+  // =========================================================================
+
+  describe("Delete", () => {
+    beforeEach(async () => {
+      await testEnv.clearDatabase();
+    });
+
+    // Helper: seed content using builders (via admin bypass)
+    const seedContent = async (updates: Record<string, any>) => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await dbFromContext(context).ref("/").update(updates);
+      });
+    };
+
+    // -- Posts --------------------------------------------------------------
+
+    it("deletes an anonymous post (no children)", async () => {
+      const createUpdates = buildCreateUpdates({
+        key: "del_post",
+        userId: uid,
+        content: "will be deleted",
+        authorDisplay: "Anonymous User",
+      });
+      await seedContent(createUpdates);
+
+      const deleteUpdates = buildDeleteUpdates(
+        { id: "del_post", parentPostId: undefined, parentReplyId: undefined },
+        uid,
+      );
+      await assertSucceeds(dbUpdate(userDb(uid), "/", deleteUpdates));
+
+      // verify everything is gone
+      const postSnap = await dbGet(guestDb(), "posts/del_post");
+      expect(postSnap.exists()).toBe(false);
+    });
+
+    it("deletes a non-anonymous post (no children)", async () => {
+      const createUpdates = buildCreateUpdates({
+        key: "del_post_named",
+        userId: uid,
+        content: "named post",
+        authorDisplay: "Jane Doe",
+      });
+      await seedContent(createUpdates);
+
+      const deleteUpdates = buildDeleteUpdates(
+        {
+          id: "del_post_named",
+          parentPostId: undefined,
+          parentReplyId: undefined,
+        },
+        uid,
+      );
+      await assertSucceeds(dbUpdate(userDb(uid), "/", deleteUpdates));
+
+      const postSnap = await dbGet(guestDb(), "posts/del_post_named");
+      expect(postSnap.exists()).toBe(false);
+    });
+
+    it("deletes a post that has replies (replies survive for cloud function cascade)", async () => {
+      // seed post + a reply
+      const postUpdates = buildCreateUpdates({
+        key: "post_with_replies",
+        userId: uid,
+        content: "has replies",
+        authorDisplay: "Anonymous User",
+      });
+      const replyUpdates = buildCreateUpdates({
+        key: "child_reply",
+        userId: uidOther,
+        content: "I am a reply",
+        authorDisplay: "Anonymous User",
+        parentPostId: "post_with_replies",
+        score: 0,
+      });
+      await seedContent({ ...postUpdates, ...replyUpdates });
+
+      // client-side delete of the post only
+      const deleteUpdates = buildDeleteUpdates(
+        {
+          id: "post_with_replies",
+          parentPostId: undefined,
+          parentReplyId: undefined,
+        },
+        uid,
+      );
+      await assertSucceeds(dbUpdate(userDb(uid), "/", deleteUpdates));
+
+      // post is gone
+      const postSnap = await dbGet(guestDb(), "posts/post_with_replies");
+      expect(postSnap.exists()).toBe(false);
+
+      // reply still exists (cloud function would clean it up)
+      const replySnap = await dbGet(
+        guestDb(),
+        "replies/post_with_replies/child_reply",
+      );
+      expect(replySnap.exists()).toBe(true);
+    });
+
+    it("deletes a post with replies that have subreplies (all children survive)", async () => {
+      const postId = "post_deep";
+      const replyId = "reply_deep";
+      const subId = "sub_deep";
+
+      await seedContent({
+        ...buildCreateUpdates({
+          key: postId,
+          userId: uid,
+          content: "deep post",
+          authorDisplay: "Anonymous User",
+        }),
+        ...buildCreateUpdates({
+          key: replyId,
+          userId: uidOther,
+          content: "deep reply",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          score: 0,
+        }),
+        ...buildCreateUpdates({
+          key: subId,
+          userId: uidOther,
+          content: "deep subreply",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          parentReplyId: replyId,
+        }),
+      });
+
+      await assertSucceeds(
+        dbUpdate(
+          userDb(uid),
+          "/",
+          buildDeleteUpdates(
+            { id: postId, parentPostId: undefined, parentReplyId: undefined },
+            uid,
+          ),
+        ),
+      );
+
+      // children survive client-side delete
+      expect(
+        (await dbGet(guestDb(), `replies/${postId}/${replyId}`)).exists(),
+      ).toBe(true);
+      expect(
+        (
+          await dbGet(guestDb(), `subreplies/${postId}/${replyId}/${subId}`)
+        ).exists(),
+      ).toBe(true);
+    });
+
+    // -- Replies ------------------------------------------------------------
+
+    it("deletes an anonymous reply (no subreplies)", async () => {
+      const postId = "rp_parent";
+      const replyId = "rp_del";
+
+      await seedContent({
+        ...buildCreateUpdates({
+          key: postId,
+          userId: uid,
+          content: "parent",
+          authorDisplay: "Anonymous User",
+        }),
+        ...buildCreateUpdates({
+          key: replyId,
+          userId: uid,
+          content: "reply to delete",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          score: 0,
+        }),
+      });
+
+      await assertSucceeds(
+        dbUpdate(
+          userDb(uid),
+          "/",
+          buildDeleteUpdates(
+            { id: replyId, parentPostId: postId, parentReplyId: undefined },
+            uid,
+          ),
+        ),
+      );
+
+      const snap = await dbGet(guestDb(), `replies/${postId}/${replyId}`);
+      expect(snap.exists()).toBe(false);
+    });
+
+    it("deletes a non-anonymous reply (no subreplies)", async () => {
+      const postId = "rp_parent2";
+      const replyId = "rp_del_named";
+
+      await seedContent({
+        ...buildCreateUpdates({
+          key: postId,
+          userId: uid,
+          content: "parent",
+          authorDisplay: "Anonymous User",
+        }),
+        ...buildCreateUpdates({
+          key: replyId,
+          userId: uid,
+          content: "named reply",
+          authorDisplay: "Real Person",
+          parentPostId: postId,
+          score: 1,
+        }),
+      });
+
+      await assertSucceeds(
+        dbUpdate(
+          userDb(uid),
+          "/",
+          buildDeleteUpdates(
+            { id: replyId, parentPostId: postId, parentReplyId: undefined },
+            uid,
+          ),
+        ),
+      );
+
+      const snap = await dbGet(guestDb(), `replies/${postId}/${replyId}`);
+      expect(snap.exists()).toBe(false);
+    });
+
+    it("deletes a reply that has subreplies (subreplies survive)", async () => {
+      const postId = "rp_cas_post";
+      const replyId = "rp_cas_reply";
+      const subId = "rp_cas_sub";
+
+      await seedContent({
+        ...buildCreateUpdates({
+          key: postId,
+          userId: uid,
+          content: "post",
+          authorDisplay: "Anonymous User",
+        }),
+        ...buildCreateUpdates({
+          key: replyId,
+          userId: uid,
+          content: "reply",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          score: 0,
+        }),
+        ...buildCreateUpdates({
+          key: subId,
+          userId: uidOther,
+          content: "sub",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          parentReplyId: replyId,
+        }),
+      });
+
+      await assertSucceeds(
+        dbUpdate(
+          userDb(uid),
+          "/",
+          buildDeleteUpdates(
+            { id: replyId, parentPostId: postId, parentReplyId: undefined },
+            uid,
+          ),
+        ),
+      );
+
+      // subreply survives client-side delete (cloud function cascades)
+      const subSnap = await dbGet(
+        guestDb(),
+        `subreplies/${postId}/${replyId}/${subId}`,
+      );
+      expect(subSnap.exists()).toBe(true);
+    });
+
+    // -- Sub-Replies --------------------------------------------------------
+
+    it("deletes an anonymous sub-reply", async () => {
+      const postId = "sr_post";
+      const replyId = "sr_reply";
+      const subId = "sr_del";
+
+      await seedContent({
+        ...buildCreateUpdates({
+          key: postId,
+          userId: uid,
+          content: "post",
+          authorDisplay: "Anonymous User",
+        }),
+        ...buildCreateUpdates({
+          key: replyId,
+          userId: uid,
+          content: "reply",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          score: 0,
+        }),
+        ...buildCreateUpdates({
+          key: subId,
+          userId: uidOther,
+          content: "sub to delete",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          parentReplyId: replyId,
+        }),
+      });
+
+      await assertSucceeds(
+        dbUpdate(
+          userDb(uidOther),
+          "/",
+          buildDeleteUpdates(
+            { id: subId, parentPostId: postId, parentReplyId: replyId },
+            uidOther,
+          ),
+        ),
+      );
+
+      const snap = await dbGet(
+        guestDb(),
+        `subreplies/${postId}/${replyId}/${subId}`,
+      );
+      expect(snap.exists()).toBe(false);
+    });
+
+    it("deletes a non-anonymous sub-reply", async () => {
+      const postId = "sr_post2";
+      const replyId = "sr_reply2";
+      const subId = "sr_del_named";
+
+      await seedContent({
+        ...buildCreateUpdates({
+          key: postId,
+          userId: uid,
+          content: "post",
+          authorDisplay: "Anonymous User",
+        }),
+        ...buildCreateUpdates({
+          key: replyId,
+          userId: uid,
+          content: "reply",
+          authorDisplay: "Anonymous User",
+          parentPostId: postId,
+          score: 0,
+        }),
+        ...buildCreateUpdates({
+          key: subId,
+          userId: uidOther,
+          content: "named sub",
+          authorDisplay: "Named Person",
+          parentPostId: postId,
+          parentReplyId: replyId,
+        }),
+      });
+
+      await assertSucceeds(
+        dbUpdate(
+          userDb(uidOther),
+          "/",
+          buildDeleteUpdates(
+            { id: subId, parentPostId: postId, parentReplyId: replyId },
+            uidOther,
+          ),
+        ),
+      );
+
+      const snap = await dbGet(
+        guestDb(),
+        `subreplies/${postId}/${replyId}/${subId}`,
+      );
+      expect(snap.exists()).toBe(false);
+    });
+
+    // -- Permission Denials -------------------------------------------------
+
+    it("denies deletion by wrong user", async () => {
+      await seedContent(
+        buildCreateUpdates({
+          key: "no_del",
+          userId: uid,
+          content: "not yours",
+          authorDisplay: "Anonymous User",
+        }),
+      );
+
+      await assertFails(
+        dbUpdate(
+          userDb(uidOther),
+          "/",
+          buildDeleteUpdates(
+            { id: "no_del", parentPostId: undefined, parentReplyId: undefined },
+            uidOther,
+          ),
+        ),
+      );
+    });
+
+    it("denies deletion by guest", async () => {
+      await seedContent(
+        buildCreateUpdates({
+          key: "no_del_guest",
+          userId: uid,
+          content: "not yours",
+          authorDisplay: "Anonymous User",
+        }),
+      );
+
+      await assertFails(
+        dbUpdate(
+          guestDb(),
+          "/",
+          buildDeleteUpdates(
+            {
+              id: "no_del_guest",
+              parentPostId: undefined,
+              parentReplyId: undefined,
+            },
+            uid,
+          ),
+        ),
+      );
+    });
+  });
+
+  // =========================================================================
+  // EDIT TESTS
+  // =========================================================================
+
+  describe("Edit", () => {
+    const postId = "edit_post";
+    const replyId = "edit_reply";
+    const subId = "edit_sub";
+
+    beforeEach(async () => {
+      await testEnv.clearDatabase();
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        const db = dbFromContext(context);
+        await db.ref("/").update({
+          ...buildCreateUpdates({
+            key: postId,
+            userId: uid,
+            content: "original",
+            authorDisplay: "Anonymous User",
+          }),
+          ...buildCreateUpdates({
+            key: replyId,
+            userId: uid,
+            content: "original reply",
+            authorDisplay: "Anonymous User",
+            parentPostId: postId,
+            score: 0,
+          }),
+          ...buildCreateUpdates({
+            key: subId,
+            userId: uid,
+            content: "original sub",
+            authorDisplay: "Anonymous User",
+            parentPostId: postId,
+            parentReplyId: replyId,
+          }),
+        });
+      });
+    });
+
+    it("allows owner to edit postContent and editedAt on a post", async () => {
+      const updates = buildEditUpdates(
+        { id: postId, parentPostId: undefined, parentReplyId: undefined },
+        { postContent: "updated content", editedAt: Date.now() },
+      );
+
+      await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+      const snap = await dbGet(guestDb(), `posts/${postId}`);
+      expect(snap.val().postContent).toBe("updated content");
+    });
+
+    it("allows owner to edit a reply", async () => {
+      const updates = buildEditUpdates(
+        { id: replyId, parentPostId: postId, parentReplyId: undefined },
+        { postContent: "updated reply", editedAt: Date.now() },
+      );
+
+      await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+      const snap = await dbGet(guestDb(), `replies/${postId}/${replyId}`);
+      expect(snap.val().postContent).toBe("updated reply");
+    });
+
+    it("allows owner to edit a sub-reply", async () => {
+      const updates = buildEditUpdates(
+        { id: subId, parentPostId: postId, parentReplyId: replyId },
+        { postContent: "updated sub", editedAt: Date.now() },
+      );
+
+      await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+
+      const snap = await dbGet(
+        guestDb(),
+        `subreplies/${postId}/${replyId}/${subId}`,
+      );
+      expect(snap.val().postContent).toBe("updated sub");
+    });
+
+    it("denies non-owner from editing", async () => {
+      const updates = buildEditUpdates(
+        { id: postId, parentPostId: undefined, parentReplyId: undefined },
+        { postContent: "hacked", editedAt: Date.now() },
+      );
+
+      await assertFails(dbUpdate(userDb(uidOther), "/", updates));
+    });
+
+    it("denies guest from editing", async () => {
+      const updates = buildEditUpdates(
+        { id: postId, parentPostId: undefined, parentReplyId: undefined },
+        { postContent: "hacked", editedAt: Date.now() },
+      );
+
+      await assertFails(dbUpdate(guestDb(), "/", updates));
+    });
+  });
+
+  // =========================================================================
+  // SHARE URL TESTS
+  // =========================================================================
+
+  describe("Share URL (buildShareUrl)", () => {
+    const origin = "https://theopendissent.com";
+
+    it("builds correct URL for a top-level post", () => {
+      const url = buildShareUrl(
+        { id: "abc", parentPostId: undefined, parentReplyId: undefined },
+        origin,
+      );
+      expect(url).toBe("https://theopendissent.com/share?s=abc");
+    });
+
+    it("builds correct URL for a reply", () => {
+      const url = buildShareUrl(
+        { id: "reply1", parentPostId: "post1", parentReplyId: undefined },
+        origin,
+      );
+      expect(url).toBe(
+        "https://theopendissent.com/share?s=reply1&p=post1",
+      );
+    });
+
+    it("builds correct URL for a sub-reply", () => {
+      const url = buildShareUrl(
+        { id: "sub1", parentPostId: "post1", parentReplyId: "reply1" },
+        origin,
+      );
+      expect(url).toBe(
+        "https://theopendissent.com/share?s=sub1&p=reply1&r=post1",
+      );
+    });
+  });
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -117,6 +117,7 @@ describe("Integration tests (updateBuilders + rules)", () => {
           const db = dbFromContext(context);
           await dbUpdate(db, "/", {
             [`posts/${parentPostId}`]: {
+              authorDisplay: "Anonymous User",
               postContent: "parent",
               timestamp: Date.now(),
               replyCount: 0,
@@ -151,14 +152,14 @@ describe("Integration tests (updateBuilders + rules)", () => {
       it("creates a non-anonymous reply", async () => {
         const updates = buildCreateUpdates({
           key: "reply_named",
-          userId: uid,
+          userId: uidOther,
           content: "Named reply",
           authorDisplay: "Jane Smith",
           parentPostId,
           score: 2,
         });
 
-        await assertSucceeds(dbUpdate(userDb(uid), "/", updates));
+        await assertSucceeds(dbUpdate(userDb(uidOther), "/", updates));
 
         const snap = await dbGet(
           guestDb(),
@@ -202,6 +203,7 @@ describe("Integration tests (updateBuilders + rules)", () => {
           const db = dbFromContext(context);
           await dbUpdate(db, "/", {
             [`posts/${parentPostId}`]: {
+              authorDisplay: "Anonymous User",
               postContent: "root",
               timestamp: Date.now(),
               replyCount: 1,
@@ -210,6 +212,7 @@ describe("Integration tests (updateBuilders + rules)", () => {
             [`users/${uid}/posts/${parentPostId}`]: true,
             [`replies/${parentPostId}/${parentReplyId}`]: {
               id: parentReplyId,
+              authorDisplay: "Anonymous User",
               postContent: "reply",
               timestamp: Date.now(),
               parentPostId,
@@ -811,9 +814,7 @@ describe("Integration tests (updateBuilders + rules)", () => {
         { id: "reply1", parentPostId: "post1", parentReplyId: undefined },
         origin,
       );
-      expect(url).toBe(
-        "https://theopendissent.com/share?s=reply1&p=post1",
-      );
+      expect(url).toBe("https://theopendissent.com/share?s=reply1&p=post1");
     });
 
     it("builds correct URL for a sub-reply", () => {


### PR DESCRIPTION
- allows cloud functions to easily find userId of anonymous posts
- needed to performantly send notifications on replies/subreplies of anonymous parent
- removes ambiguity of userId being included in main post object (will be removed)
- requires a migration script to delete all `userId` fields from public posts, move to authorLookup