### PR TITLE
Don't re-render feed list except for first load

### DIFF
--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -85,7 +85,7 @@ export const FeedItem = memo(
     const isLong = item.postContent.length > CONTENT_CHAR_LIMIT;
     const displayContent =
       !isExpanded && isLong
-        ? item.postContent.slice(0, CONTENT_CHAR_LIMIT) + "..."
+        ? item.postContent.slice(0, CONTENT_CHAR_LIMIT).trimEnd() + "..."
         : item.postContent;
 
     const toggleExpansion = (e: React.MouseEvent) => {

--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -19,7 +19,8 @@ interface FeedItemProps {
   onReply?: () => void;
 }
 
-const CONTENT_CHAR_LIMIT = 300;
+const CONTENT_CHAR_LIMIT = 250;
+const expandedPostIds = new Set<string>(); // module level cache per session
 
 export const FeedItem = memo(
   ({
@@ -78,12 +79,25 @@ export const FeedItem = memo(
     const actionButtonClass =
       "flex items-center justify-center py-4 text-slate-400 hover:bg-slate-100 active:bg-slate-200/60 transition-all";
 
-    const [isExpanded, setIsExpanded] = useState(disableClick);
+    const [isExpanded, setIsExpanded] = useState(
+      () => disableClick || expandedPostIds.has(item.id),
+    );
     const isLong = item.postContent.length > CONTENT_CHAR_LIMIT;
     const displayContent =
       !isExpanded && isLong
         ? item.postContent.slice(0, CONTENT_CHAR_LIMIT) + "..."
         : item.postContent;
+
+    const toggleExpansion = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const next = !isExpanded;
+      setIsExpanded(next);
+      if (next) {
+        expandedPostIds.add(item.id);
+      } else {
+        expandedPostIds.delete(item.id);
+      }
+    };
 
     const handleContentClick = (e: React.MouseEvent) => {
       if (disableClick || isEditing || isReply) return;
@@ -205,11 +219,8 @@ export const FeedItem = memo(
               </p>
               {isLong && !disableClick && (
                 <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsExpanded(!isExpanded);
-                  }}
-                  className="flex items-center gap-x-1.5 mx-auto py-1.5 text-sm font-semibold text-slate-400 cursor-pointer self-start hover:bg-slate-100 active:bg-slate-200/60 transition-all rounded-xl p-3"
+                  onClick={toggleExpansion}
+                  className="flex items-center gap-x-1.5 px-4 py-2 text-sm font-semibold text-slate-400 hover:text-slate-600 transition-colors self-start -ml-4"
                 >
                   <i
                     className={`bi ${isExpanded ? "bi-arrow-up" : "bi-arrow-down"} text-base leading-none`}

--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -96,7 +96,7 @@ export const FeedList = ({
               <motion.div
                 layout
                 key={`highlight-${highlightedPost.id}`}
-                initial={{ opacity: 0, y: 12 }}
+                initial={shouldAnimateInitial ? { opacity: 0, y: 12 } : false}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.98 }}
                 transition={{ duration: 0.3, ease: "easeOut" }}
@@ -116,7 +116,7 @@ export const FeedList = ({
                 layout
                 key={post.id}
                 id={`post-${post.id}`}
-                initial={{ opacity: 0, y: 12 }}
+                initial={shouldAnimateInitial ? { opacity: 0, y: 12 } : false}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.98 }}
                 transition={{ duration: 0.3, ease: "easeOut" }}

--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -5,6 +5,7 @@ import { FeedItem } from "./FeedItem";
 import { FeedItemSkeleton } from "../ui/FeedItemSkeleton";
 import { Post } from "../../types";
 import { useInfiniteScroll } from "../../hooks/useInfininteScroll";
+import { useNavigationType } from "react-router-dom";
 
 interface FeedListProps {
   posts: Post[];
@@ -14,6 +15,8 @@ interface FeedListProps {
   onLoadMore: () => void;
 }
 
+let isInitialMount = true;
+
 export const FeedList = ({
   posts,
   highlightedPost,
@@ -21,6 +24,17 @@ export const FeedList = ({
   hasMore,
   onLoadMore,
 }: FeedListProps) => {
+  const navType = useNavigationType();
+  const isPop = navType === "POP";
+
+  // If this is the first time the app is loading, we want the premium fade-in.
+  // If we are navigating back (POP), we skip it to prevent iOS jitter.
+  const shouldAnimateInitial = isInitialMount || !isPop;
+
+  useEffect(() => {
+    isInitialMount = false;
+  }, []);
+
   const bottomBoundaryRef = useInfiniteScroll({
     loading,
     hasMore,
@@ -62,7 +76,7 @@ export const FeedList = ({
   return (
     <div className="flex flex-col w-full max-w-2xl mx-auto gap-3 min-h-100">
       <div className="flex flex-col gap-3 w-full">
-        <AnimatePresence mode="popLayout">
+        <AnimatePresence mode="popLayout" initial={shouldAnimateInitial}>
           {loading && showLoadingUI && posts.length === 0 && (
             <motion.div
               key="skeletons"

--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -45,9 +45,12 @@ export const FeedList = ({
 
   // Skeleton delay logic
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
+    let timeoutId: number;
     if (loading) {
-      timeoutId = setTimeout(() => setShowLoadingUI(true), 1000);
+      timeoutId = setTimeout(
+        () => setShowLoadingUI(true),
+        1000,
+      ) as unknown as number;
     } else {
       setShowLoadingUI(false);
     }

--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -79,7 +79,7 @@ export const FeedList = ({
   return (
     <div className="flex flex-col w-full max-w-2xl mx-auto gap-3 min-h-100">
       <div className="flex flex-col gap-3 w-full">
-        <AnimatePresence mode="popLayout" initial={shouldAnimateInitial}>
+        <AnimatePresence initial={shouldAnimateInitial}>
           {loading && showLoadingUI && posts.length === 0 && (
             <motion.div
               key="skeletons"

--- a/src/components/feed/FeedList.tsx
+++ b/src/components/feed/FeedList.tsx
@@ -65,7 +65,7 @@ export const FeedList = ({
         <AnimatePresence mode="popLayout">
           {loading && showLoadingUI && posts.length === 0 && (
             <motion.div
-              key="loading-skeletons"
+              key="skeletons"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -82,7 +82,7 @@ export const FeedList = ({
               <motion.div
                 layout
                 key={`highlight-${highlightedPost.id}`}
-                initial={{ opacity: 0, y: 10 }}
+                initial={{ opacity: 0, y: 12 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.98 }}
                 transition={{ duration: 0.3, ease: "easeOut" }}

--- a/src/components/feed/SubReplyThread.tsx
+++ b/src/components/feed/SubReplyThread.tsx
@@ -196,7 +196,7 @@ export const SubReplyThread = ({
                       >
                         <motion.div
                           layout
-                          initial={{ opacity: 0 }}
+                          initial={shouldAnimateInitial ? { opacity: 0 } : false}
                           animate={{ opacity: 1 }}
                           exit={{ opacity: 0 }}
                           transition={{ duration: 0.2, ease: "easeOut" }}

--- a/src/components/feed/SubReplyThread.tsx
+++ b/src/components/feed/SubReplyThread.tsx
@@ -3,9 +3,11 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Post } from "../../types";
 import { subscribeToSubRepliesWithGap } from "../../lib/firebase";
 import { FeedItem } from "./FeedItem";
-import { useOutletContext } from "react-router-dom";
+import { useOutletContext, useNavigationType } from "react-router-dom";
 
 const PAGE_SIZE = 3;
+
+let isInitialMount = true;
 
 interface SubReplyThreadProps {
   parentPostId: string;
@@ -28,8 +30,15 @@ export const SubReplyThread = ({
 }: SubReplyThreadProps) => {
   // Grab the global target from Layout context
   const { activeTarget, setActiveTarget }: any = useOutletContext();
+  const navType = useNavigationType();
 
   const [expanded, setExpanded] = useState(false);
+
+  const shouldAnimateInitial = isInitialMount || navType !== "POP";
+
+  useEffect(() => {
+    isInitialMount = false;
+  }, []);
   const [topLimit, setTopLimit] = useState(2);
   const [subReplies, setSubReplies] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
@@ -151,7 +160,7 @@ export const SubReplyThread = ({
       </button>
 
       {/* Expanded thread */}
-      <AnimatePresence>
+      <AnimatePresence initial={shouldAnimateInitial}>
         {expanded && !isInitialLoading && (
           <motion.div
             layout
@@ -174,7 +183,7 @@ export const SubReplyThread = ({
 
               {/* Sub-reply list */}
               <div className="flex-1 flex flex-col gap-y-2 min-w-0">
-                <AnimatePresence>
+                <AnimatePresence initial={shouldAnimateInitial}>
                   {subReplies.map((sr, index) => {
                     // Check if this is the end of the top block (index = topLimit - 1)
                     const isEndOfTop = hasGap && index === topLimit - 1;

--- a/src/pages/PostDetails.tsx
+++ b/src/pages/PostDetails.tsx
@@ -47,9 +47,37 @@ export const PostDetails = () => {
   const [livePost, setLivePost] = useState<Post | null>(null);
   const [isLoadingPost, setIsLoadingPost] = useState(true);
 
+  // Skeletons should only show if loading takes a while to prevent "flashing"
+  const [showPostSkeleton, setShowPostSkeleton] = useState(false);
+  const [showRepliesSkeleton, setShowRepliesSkeleton] = useState(false);
+
   const { loading: authLoading } = useAuth();
-  // const uid = user?.uid;
-  // const ownedPosts = useOwnedPosts();
+
+  useEffect(() => {
+    let timeoutId: number;
+    if (isLoadingPost || authLoading) {
+      timeoutId = setTimeout(
+        () => setShowPostSkeleton(true),
+        1000,
+      ) as unknown as number;
+    } else {
+      setShowPostSkeleton(false);
+    }
+    return () => clearTimeout(timeoutId);
+  }, [isLoadingPost, authLoading]);
+
+  useEffect(() => {
+    let t: number;
+    if (isLoadingReplies) {
+      t = setTimeout(
+        () => setShowRepliesSkeleton(true),
+        1000,
+      ) as unknown as number;
+    } else {
+      setShowRepliesSkeleton(false);
+    }
+    return () => clearTimeout(t);
+  }, [isLoadingReplies]);
 
   // set the active parent for the FAB when the post loads
   useEffect(() => {
@@ -142,7 +170,7 @@ export const PostDetails = () => {
 
       <main className="flex flex-col gap-y-8">
         <section>
-          {isLoadingPost || authLoading ? (
+          {showPostSkeleton ? (
             <FeedItemSkeleton />
           ) : livePost ? (
             <FeedItem item={livePost} disableClick={true} isReply={false} />
@@ -157,7 +185,7 @@ export const PostDetails = () => {
         <section className="flex flex-col gap-y-4">
           <ComposeTrigger placeholder="Your thoughts?" />
           <AnimatePresence mode="popLayout" initial={shouldAnimateInitial}>
-            {isLoadingReplies ? (
+            {showRepliesSkeleton && replies.length === 0 ? (
               <motion.div
                 key="skeletons"
                 initial={{ opacity: 0 }}

--- a/src/pages/PostDetails.tsx
+++ b/src/pages/PostDetails.tsx
@@ -184,7 +184,7 @@ export const PostDetails = () => {
 
         <section className="flex flex-col gap-y-4">
           <ComposeTrigger placeholder="Your thoughts?" />
-          <AnimatePresence mode="popLayout" initial={shouldAnimateInitial}>
+          <AnimatePresence initial={shouldAnimateInitial}>
             {showRepliesSkeleton && replies.length === 0 ? (
               <motion.div
                 key="skeletons"

--- a/src/pages/PostDetails.tsx
+++ b/src/pages/PostDetails.tsx
@@ -175,7 +175,7 @@ export const PostDetails = () => {
                   layout
                   key={reply.id}
                   id={`reply-${reply.id}`}
-                  initial={{ opacity: 0, y: 12 }}
+                  initial={shouldAnimateInitial ? { opacity: 0, y: 12 } : false}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, scale: 0.98 }}
                   transition={{ duration: 0.3, ease: "easeOut" }}

--- a/src/pages/PostDetails.tsx
+++ b/src/pages/PostDetails.tsx
@@ -6,6 +6,7 @@ import {
   useNavigate,
   useSearchParams,
   useOutletContext,
+  useNavigationType,
 } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { subscribeToPost, subscribeToReplies } from "../lib/firebase";
@@ -16,12 +17,21 @@ import { Post } from "../types";
 import { FeedItemSkeleton } from "../components/ui/FeedItemSkeleton";
 import { ComposeTrigger } from "../components/feed/ComposeTrigger";
 
+let isInitialMount = true;
+
 export const PostDetails = () => {
   const { postId } = useParams<{ postId: string }>();
   const [searchParams] = useSearchParams();
   const highlightReplyId = searchParams.get("reply");
   const highlightSubReplyId = searchParams.get("subreply");
   const navigate = useNavigate();
+  const navType = useNavigationType();
+
+  const shouldAnimateInitial = isInitialMount || navType !== "POP";
+
+  useEffect(() => {
+    isInitialMount = false;
+  }, []);
 
   // grab the setters from Layout
   const {
@@ -146,7 +156,7 @@ export const PostDetails = () => {
 
         <section className="flex flex-col gap-y-4">
           <ComposeTrigger placeholder="Your thoughts?" />
-          <AnimatePresence mode="popLayout">
+          <AnimatePresence mode="popLayout" initial={shouldAnimateInitial}>
             {isLoadingReplies ? (
               <motion.div
                 key="skeletons"


### PR DESCRIPTION
On iOS (Safari) swiping from the side of the screen causes a re-render and triggers the load animation. This should be skipped except for first load. 